### PR TITLE
PIP-28 namespace redis keys

### DIFF
--- a/src/cli/com/yetanalytics/xapipe/cli.clj
+++ b/src/cli/com/yetanalytics/xapipe/cli.clj
@@ -26,7 +26,8 @@
 (defn create-store
   [{:keys [storage
            redis-host
-           redis-port]}]
+           redis-port
+           redis-prefix]}]
   (case storage
     :noop (noop-store/new-store)
     :redis (if (and redis-host redis-port)
@@ -36,7 +37,8 @@
                :spec
                {:uri (format "redis://%s:%d"
                              redis-host
-                             redis-port)}})
+                             redis-port)}}
+              redis-prefix)
              (throw (ex-info "Redis Config Required!"
                              {:type ::redis-config-required})))
     :mem (mem-store/new-store)))

--- a/src/cli/com/yetanalytics/xapipe/cli/options.clj
+++ b/src/cli/com/yetanalytics/xapipe/cli/options.clj
@@ -19,7 +19,9 @@
     :default "0.0.0.0"]
    [nil "--redis-port PORT" "Redis Port"
     :default 6379
-    :parse-fn #(Long/parseLong %)]])
+    :parse-fn #(Long/parseLong %)]
+   [nil "--redis-prefix" "Redis key prefix"
+    :default "xapipe"]])
 
 (defn- keywordize-status
   [job]

--- a/src/test/com/yetanalytics/xapipe/cli/options_test.clj
+++ b/src/test/com/yetanalytics/xapipe/cli/options_test.clj
@@ -18,7 +18,8 @@
      :force-resume false,
      :storage :noop,
      :redis-host "0.0.0.0",
-     :redis-port 6379}
+     :redis-port 6379,
+     :redis-prefix "xapipe"}
     nil
 
     ;; Redis store with a custom port
@@ -28,7 +29,8 @@
      :force-resume false,
      :storage :redis,
      :redis-host "0.0.0.0",
-     :redis-port 1234}
+     :redis-port 1234,
+     :redis-prefix "xapipe"}
     nil))
 
 (deftest source-options-test


### PR DESCRIPTION
[PIP-28] Namespace Redis Keys

Configurable by the user.

[PIP-28]: https://yet.atlassian.net/browse/PIP-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ