### PR TITLE
PIP-33 Redis URI instead of host + port

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,48 +58,47 @@ Delete a Job:
     --delete-job <id>
 
 All options:
-  -h, --help                                     Show the help and options summary
-      --job-id ID                                Job ID
-      --conn-timeout TIMEOUT                     Connection Manager Connection Timeout
-      --conn-threads THREADS                     Connection Manager Max Threads
-      --conn-default-per-route CONNS             Connection Manager Simultaneous Connections Per Host
-      --conn-insecure?                           Allow Insecure HTTPS Connections
-      --conn-io-thread-count THREADS             Connection Manager I/O Thread Pool Size, default is number of processors
-      --show-job                                 Show the job and exit
-      --list-jobs                                List jobs in persistent storage
-      --delete-job ID                            Delete the job specified and exit.
-  -f, --force-resume                             If resuming a job, clear any errors and force it to resume.
-      --json JSON                                Take a job specification as a JSON string
-      --json-file FILE                           Take a job specification from a JSON file
-  -s, --storage STORAGE                 :noop    Select storage backend, noop (default) or redis, mem is for testing only
-      --redis-host HOST                 0.0.0.0  Redis Host
-      --redis-port PORT                 6379     Redis Port
-      --redis-prefix                             Redis key prefix
-      --file-store-dir PATH             store    Directory path for filesystem storage
-      --source-url URL                           Source LRS xAPI Endpoint
-      --source-batch-size SIZE          50       Source LRS GET limit param
-      --source-poll-interval INTERVAL   1000     Source LRS GET poll timeout
-  -p, --xapi-get-param KEY=VALUE        {}       xAPI GET Parameters
-      --source-username USERNAME                 Source LRS BASIC Auth username
-      --source-password PASSWORD                 Source LRS BASIC Auth password
-      --source-backoff-budget BUDGET    10000    Source LRS Retry Backoff Budget in ms
-      --source-backoff-max-attempt MAX  10       Source LRS Retry Backoff Max Attempts, set to -1 for no retry
-      --source-backoff-j-range RANGE             Source LRS Retry Backoff Jitter Range in ms
-      --source-backoff-initial INITIAL           Source LRS Retry Backoff Initial Delay
-      --target-url URL                           Target LRS xAPI Endpoint
-      --target-batch-size SIZE          50       Target LRS POST desired batch size
-      --target-username USERNAME                 Target LRS BASIC Auth username
-      --target-password PASSWORD                 Target LRS BASIC Auth password
-      --target-backoff-budget BUDGET    10000    Target LRS Retry Backoff Budget in ms
-      --target-backoff-max-attempt MAX  10       Target LRS Retry Backoff Max Attempts, set to -1 for no retry
-      --target-backoff-j-range RANGE             Target LRS Retry Backoff Jitter Range in ms
-      --target-backoff-initial INITIAL           Target LRS Retry Backoff Initial Delay
-      --get-buffer-size SIZE            10       Size of GET response buffer
-      --batch-timeout TIMEOUT           200      Msecs to wait for a fully formed batch
-      --template-profile-url URL        []       Profile URL/location from which to apply statement template filters
-      --template-id IRI                 []       Statement template IRIs to filter on
-      --pattern-profile-url URL         []       Profile URL/location from which to apply statement pattern filters
-      --pattern-id IRI                  []       Pattern IRIs to filter on
-      --statement-buffer-size SIZE               Desired size of statement buffer
-      --batch-buffer-size SIZE                   Desired size of statement batch buffer
+  -h, --help                                                  Show the help and options summary
+      --job-id ID                                             Job ID
+      --conn-timeout TIMEOUT                                  Connection Manager Connection Timeout
+      --conn-threads THREADS                                  Connection Manager Max Threads
+      --conn-default-per-route CONNS                          Connection Manager Simultaneous Connections Per Host
+      --conn-insecure?                                        Allow Insecure HTTPS Connections
+      --conn-io-thread-count THREADS                          Connection Manager I/O Thread Pool Size, default is number of processors
+      --show-job                                              Show the job and exit
+      --list-jobs                                             List jobs in persistent storage
+      --delete-job ID                                         Delete the job specified and exit.
+  -f, --force-resume                                          If resuming a job, clear any errors and force it to resume.
+      --json JSON                                             Take a job specification as a JSON string
+      --json-file FILE                                        Take a job specification from a JSON file
+  -s, --storage STORAGE                 :noop                 Select storage backend, noop (default) or redis, mem is for testing only
+      --redis-uri URI                   redis://0.0.0.0:6379  Redis Connection URI
+      --redis-prefix                                          Redis key prefix
+      --file-store-dir PATH             store                 Directory path for filesystem storage
+      --source-url URL                                        Source LRS xAPI Endpoint
+      --source-batch-size SIZE          50                    Source LRS GET limit param
+      --source-poll-interval INTERVAL   1000                  Source LRS GET poll timeout
+  -p, --xapi-get-param KEY=VALUE        {}                    xAPI GET Parameters
+      --source-username USERNAME                              Source LRS BASIC Auth username
+      --source-password PASSWORD                              Source LRS BASIC Auth password
+      --source-backoff-budget BUDGET    10000                 Source LRS Retry Backoff Budget in ms
+      --source-backoff-max-attempt MAX  10                    Source LRS Retry Backoff Max Attempts, set to -1 for no retry
+      --source-backoff-j-range RANGE                          Source LRS Retry Backoff Jitter Range in ms
+      --source-backoff-initial INITIAL                        Source LRS Retry Backoff Initial Delay
+      --target-url URL                                        Target LRS xAPI Endpoint
+      --target-batch-size SIZE          50                    Target LRS POST desired batch size
+      --target-username USERNAME                              Target LRS BASIC Auth username
+      --target-password PASSWORD                              Target LRS BASIC Auth password
+      --target-backoff-budget BUDGET    10000                 Target LRS Retry Backoff Budget in ms
+      --target-backoff-max-attempt MAX  10                    Target LRS Retry Backoff Max Attempts, set to -1 for no retry
+      --target-backoff-j-range RANGE                          Target LRS Retry Backoff Jitter Range in ms
+      --target-backoff-initial INITIAL                        Target LRS Retry Backoff Initial Delay
+      --get-buffer-size SIZE            10                    Size of GET response buffer
+      --batch-timeout TIMEOUT           200                   Msecs to wait for a fully formed batch
+      --template-profile-url URL        []                    Profile URL/location from which to apply statement template filters
+      --template-id IRI                 []                    Statement template IRIs to filter on
+      --pattern-profile-url URL         []                    Profile URL/location from which to apply statement pattern filters
+      --pattern-id IRI                  []                    Pattern IRIs to filter on
+      --statement-buffer-size SIZE                            Desired size of statement buffer
+      --batch-buffer-size SIZE                                Desired size of statement batch buffer
 ```

--- a/src/cli/com/yetanalytics/xapipe/cli.clj
+++ b/src/cli/com/yetanalytics/xapipe/cli.clj
@@ -28,23 +28,17 @@
 
 (defn create-store
   [{:keys [storage
-           redis-host
-           redis-port
+           redis-uri
            redis-prefix
            file-store-dir]}]
   (case storage
     :noop (noop-store/new-store)
-    :redis (if (and redis-host redis-port)
-             (redis-store/new-store
-              ;; TODO: Pool?
-              {:pool {}
-               :spec
-               {:uri (format "redis://%s:%d"
-                             redis-host
-                             redis-port)}}
-              redis-prefix)
-             (throw (ex-info "Redis Config Required!"
-                             {:type ::redis-config-required})))
+    :redis (redis-store/new-store
+            ;; TODO: Pool?
+            {:pool {}
+             :spec
+             {:uri redis-uri}}
+            redis-prefix)
     :mem (mem-store/new-store)
     :file (file-store/new-store file-store-dir)))
 

--- a/src/cli/com/yetanalytics/xapipe/cli/options.clj
+++ b/src/cli/com/yetanalytics/xapipe/cli/options.clj
@@ -15,12 +15,8 @@
                  :mem
                  :file} "Must be: noop | redis | mem | file"]]
    ;; Redis Backend Options
-   ;; TODO: auth, or just let them pass the redis url
-   [nil "--redis-host HOST" "Redis Host"
-    :default "0.0.0.0"]
-   [nil "--redis-port PORT" "Redis Port"
-    :default 6379
-    :parse-fn #(Long/parseLong %)]
+   [nil "--redis-uri URI" "Redis Connection URI"
+    :default "redis://0.0.0.0:6379"]
    [nil "--redis-prefix" "Redis key prefix"
     :default "xapipe"]
    [nil "--file-store-dir PATH" "Directory path for filesystem storage"

--- a/src/test/com/yetanalytics/xapipe/cli/options_test.clj
+++ b/src/test/com/yetanalytics/xapipe/cli/options_test.clj
@@ -18,21 +18,19 @@
      :list-jobs false,
      :force-resume false,
      :storage :noop,
-     :redis-host "0.0.0.0",
-     :redis-port 6379,
+     :redis-uri "redis://0.0.0.0:6379",
      :redis-prefix "xapipe"
      :file-store-dir "store"}
     nil
 
-    ;; Redis store with a custom port
-    ["-s" "redis" "--redis-port" "1234"]
+    ;; Redis store with a custom uri
+    ["-s" "redis" "--redis-uri" "redis://localhost:1234"]
     {:help false,
      :show-job false,
      :list-jobs false,
      :force-resume false,
      :storage :redis,
-     :redis-host "0.0.0.0",
-     :redis-port 1234,
+     :redis-uri "redis://localhost:1234",
      :redis-prefix "xapipe"
      :file-store-dir "store"}
     nil))

--- a/src/test/com/yetanalytics/xapipe/cli_test.clj
+++ b/src/test/com/yetanalytics/xapipe/cli_test.clj
@@ -6,8 +6,8 @@
 (deftest create-store-test
   (is (satisfies? store/XapipeStore (create-store {:storage :noop})))
   (is (satisfies? store/XapipeStore (create-store {:storage :redis
-                                                   :redis-host "localhost"
-                                                   :redis-port 1234})))
+                                                   :redis-uri "redis://0.0.0.0:6379"
+                                                   :refis-prefix "whatever"})))
   (is (satisfies? store/XapipeStore (create-store {:storage :mem}))))
 
 (deftest parse-lrs-url-test


### PR DESCRIPTION
[PIP-33] Use a uri string for redis

[PIP-33]: https://yet.atlassian.net/browse/PIP-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ