### PR TITLE
PIP-40 obscure LRS passwords in logs

### DIFF
--- a/src/cli/com/yetanalytics/xapipe/main.clj
+++ b/src/cli/com/yetanalytics/xapipe/main.clj
@@ -80,11 +80,20 @@ Delete a Job:
             (if (s/valid? job/job-spec job)
               (do
                 (if new?
-                  (log/infof "Created new job %s: %s" (:id job) (pr-str job))
-                  (log/infof "Found existing job %s: %s" (:id job) (pr-str job)))
+                  (log/infof
+                   "Created new job %s: %s"
+                   (:id job)
+                   (pr-str
+                    (job/sanitize job)))
+                  (log/infof
+                   "Found existing job %s: %s"
+                   (:id job)
+                   (pr-str
+                    (job/sanitize job))))
                 (if show-job?
                   {:status 0
-                   :message (pr-str job)}
+                   :message (pr-str
+                             (job/sanitize job))}
                   (do
                     (log/infof
                      (if new?

--- a/src/lib/com/yetanalytics/xapipe/job.clj
+++ b/src/lib/com/yetanalytics/xapipe/job.clj
@@ -63,3 +63,19 @@
   "Check if a job has any errors"
   [{:keys [state]}]
   (state/errors? state))
+
+(s/fdef sanitize
+  :args (s/cat :job job-spec)
+  :ret (s/and job-spec
+              (fn [{{{{src-pw :password} :request-config} :source
+                     {{tgt-pw :password} :request-config} :target}
+                    :config}]
+                (and (or (nil? src-pw)
+                         (= "************" src-pw))
+                     (or (nil? tgt-pw)
+                         (= "************" tgt-pw))))))
+
+(defn sanitize
+  "Sanitize any sensitive info on a job for logging, etc"
+  [job]
+  (update job :config config/sanitize))

--- a/src/lib/com/yetanalytics/xapipe/job/state/errors.clj
+++ b/src/lib/com/yetanalytics/xapipe/job/state/errors.clj
@@ -7,4 +7,5 @@
 (s/def ::error (s/keys :req-un [::message
                                 ::type]))
 
-(def errors-spec (s/every ::error))
+(def errors-spec (s/every ::error
+                          :gen-max 5))

--- a/src/test/com/yetanalytics/xapipe/job/config_test.clj
+++ b/src/test/com/yetanalytics/xapipe/job/config_test.clj
@@ -4,8 +4,6 @@
             [com.yetanalytics.xapipe.job.config :refer :all]
             [com.yetanalytics.xapipe.test-support :as sup]))
 
-(use-fixtures :once (sup/instrument-fixture))
-
 (def minimal-config
   {:source
    {:request-config {:url-base "http://0.0.0.0:8080"
@@ -14,7 +12,7 @@
    {:request-config {:url-base "http://0.0.0.0:8081"
                      :xapi-prefix "/xapi"}}})
 
-(deftest ensure-defaults-test
+(deftest minimal-config-test
   (testing "produces valid config"
     (is (s/valid? config-spec (ensure-defaults minimal-config))))
   (testing "idempotent"
@@ -23,3 +21,7 @@
            (ensure-defaults
             (ensure-defaults
              minimal-config))))))
+
+(sup/def-ns-check-tests
+  com.yetanalytics.xapipe.job.config
+  {:default {sup/stc-opts {:num-tests 10}}})

--- a/src/test/com/yetanalytics/xapipe/job_test.clj
+++ b/src/test/com/yetanalytics/xapipe/job_test.clj
@@ -4,8 +4,6 @@
             [com.yetanalytics.xapipe.job :refer :all]
             [com.yetanalytics.xapipe.test-support :as sup]))
 
-(use-fixtures :once (sup/instrument-fixture))
-
 (def minimal-config
   {:source
    {:request-config {:url-base "http://0.0.0.0:8080"
@@ -19,7 +17,7 @@
     (is (s/valid? :com.yetanalytics.xapipe.job/config
                   minimal-config))))
 
-(deftest init-job-test
+(deftest init-job-defaults-test
   (testing "given an id and minimal config it constructs a valid job"
     (is (s/valid? job-spec
                   (init-job
@@ -56,3 +54,7 @@
            (init-job
             "foo"
             minimal-config)))))
+
+(sup/def-ns-check-tests
+  com.yetanalytics.xapipe.job
+  {:default {sup/stc-opts {:num-tests 10}}})


### PR DESCRIPTION
[PIP-40]

Output is obscured like so:

```clojure
bin/run.sh --source-url http://0.0.0.0:8080/xapi --source-username foo --s
ource-password bar --target-url http://0.0.0.0:8081/xapi --target-username foo --target-password
bar
Nov 10, 2021 4:27:30 PM com.yetanalytics.xapipe.main invoke
INFO: Created new job 5082ac79-4d59-4b14-adbf-ae8d104685c1: {:id "5082ac79-4d59-4b14-adbf-ae8d104685c1", :config {:get-buffer-size 10, :statement-buffer-size 500, :batch-buffer-size 10, :batch-timeout 200, :source {:request-config {:url-base "http://0.0.0.0:8080", :xapi-prefix "/xapi", :username "foo", :password "************"}, :get-params {:limit 50}, :poll-interval 1000, :batch-size 50, :backoff-opts {:budget 10000, :max-attempt 10}}, :target {:request-config {:url-base "http://0.0.0.0:8081", :xapi-prefix "/xapi", :username "foo", :password "************"}, :batch-size 50, :backoff-opts {:budget 10000, :max-attempt 10}}, :filter {}}, :state {:status :init, :cursor "1970-01-01T00:00:00Z", :source {:errors []}, :target {:errors []}, :errors [], :filter {}}}
Nov 10, 2021 4:27:30 PM com.yetanalytics.xapipe.main invoke
INFO: Starting job 5082ac79-4d59-4b14-adbf-ae8d104685c1
Nov 10, 2021 4:27:30 PM com.yetanalytics.xapipe invoke
INFO: Job ID 5082ac79-4d59-4b14-adbf-ae8d104685c1 state: {:status :init, :cursor "1970-01-01T00:00:00Z", :source {:errors []}, :target {:errors []}, :errors [], :filter {}}
Nov 10, 2021 4:27:30 PM com.yetanalytics.xapipe invoke
INFO: Job ID 5082ac79-4d59-4b14-adbf-ae8d104685c1 state: {:status :running, :cursor "1970-01-01T00:00:00Z", :source {:errors []}, :target {:errors []}, :errors [], :filter {}}
```

[PIP-40]: https://yet.atlassian.net/browse/PIP-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ