### PR TITLE
Tweaks 2021-11-10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,21 @@ on:
       - '*'
 
 jobs:
+  get_modules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: echo-modules
+        run: echo "::set-output name=modules::$(cat .java_modules)"
+    outputs:
+      modules: ${{ steps.echo-modules.outputs.modules }}
   build_jre:
+    needs: get_modules
     uses: yetanalytics/runtimer/.github/workflows/runtimer.yml@cf8c77d465f08962cd7901005b8cf197a6149ac1
     with:
       java-version: '11'
       java-distribution: 'temurin'
-      java-modules: 'java.base,java.logging,java.naming,java.sql,java.management'
+      java-modules: ${{ needs.get_modules.outputs.modules }}
 
   build:
     needs: build_jre

--- a/Makefile
+++ b/Makefile
@@ -19,37 +19,13 @@ target/bundle/bin:
 	chmod +x target/bundle/bin/*.sh
 
 # Make Runtime Environment (i.e. JREs)
-
-# The given tag to pull down from yetanalytics/runtimer release
-RUNTIME_TAG ?= 0.1.1-java-11-temurin
-RUNTIME_MACHINE ?= macos
-RUNTIME_MACHINE_BUILD ?= macos-10.15
-RUNTIME_ZIP_DIR ?= tmp/runtimes/${RUNTIME_TAG}
-RUNTIME_ZIP ?= ${RUNTIME_ZIP_DIR}/${RUNTIME_MACHINE}.zip
+# Will only produce a single jre for macos/linux matching your machine
+MACHINE ?= $(shell bin/machine.sh)
 JAVA_MODULES ?= $(shell cat .java_modules)
 
-# DEBUG: Kept here for reference
-# target/bundle/runtimes: target/bundle/bin
-# 	mkdir target/bundle/runtimes
-# 	jlink --output target/bundle/runtimes/$(MACHINE_TYPE) --add-modules $(JAVA_MODULES)
-
-target/bundle/runtimes/%:
-	mkdir -p ${RUNTIME_ZIP_DIR}
+target/bundle/runtimes:
 	mkdir -p target/bundle/runtimes
-	[ ! -f ${RUNTIME_ZIP} ] && curl -L -o ${RUNTIME_ZIP} https://github.com/yetanalytics/runtimer/releases/download/${RUNTIME_TAG}/${RUNTIME_MACHINE_BUILD}-jre.zip || echo 'already present'
-	unzip ${RUNTIME_ZIP} -d target/bundle/runtimes/
-	mv target/bundle/runtimes/${RUNTIME_MACHINE_BUILD} target/bundle/runtimes/${RUNTIME_MACHINE}
-
-target/bundle/runtimes/macos: RUNTIME_MACHINE = macos
-target/bundle/runtimes/macos: RUNTIME_MACHINE_BUILD = macos-10.15
-
-target/bundle/runtimes/linux: RUNTIME_MACHINE = linux
-target/bundle/runtimes/linux: RUNTIME_MACHINE_BUILD = ubuntu-20.04
-
-target/bundle/runtimes/windows: RUNTIME_MACHINE = windows
-target/bundle/runtimes/windows: RUNTIME_MACHINE_BUILD = windows-2019
-
-target/bundle/runtimes: target/bundle/runtimes/macos target/bundle/runtimes/linux target/bundle/runtimes/windows
+	jlink --output target/bundle/runtimes/${MACHINE}/ --add-modules ${JAVA_MODULES}
 
 BUNDLE_RUNTIMES ?= true
 

--- a/src/cli/logback.xml
+++ b/src/cli/logback.xml
@@ -1,4 +1,4 @@
-<configuration scan="true" scanPeriod="5 seconds">
+<configuration scan="false">
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>


### PR DESCRIPTION
A few misc dev + performance tweaks, none of which need a new version:
* use single modules list from file in dev + release scripting
* Don't download old LRSQL jre
* Turn off prod logback file scanning