### PR TITLE
PIP-50 Don't use consistent-through header to advance GET loop

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -22,6 +22,11 @@
                      ch.qos.logback/logback-classic
                      {:mvn/version "1.2.3"
                       :exclusions [org.slf4j/slf4j-api]}
+                     org.slf4j/slf4j-api {:mvn/version "1.7.26"}
+                     org.slf4j/jul-to-slf4j {:mvn/version "1.7.26"}
+                     org.slf4j/jcl-over-slf4j {:mvn/version "1.7.26"}
+                     org.slf4j/log4j-over-slf4j {:mvn/version "1.7.26"}
+
                      clj-commons/iapetos {:mvn/version "0.1.12"}
                      io.prometheus/simpleclient_hotspot {:mvn/version "0.12.0"}}}
   :test {:extra-paths ["src/test"]

--- a/src/lib/com/yetanalytics/xapipe/client.clj
+++ b/src/lib/com/yetanalytics/xapipe/client.clj
@@ -386,17 +386,17 @@
                       (a/close! out-chan))
                     ;; With no more link or until, we're polling.
                     ;; Wait for the specified time
-                    :else (do
+                    :else (let [next-since (or ?last-stored since)]
                             (log/debugf "waiting %d ms..." poll-interval)
                             (a/<! (a/timeout poll-interval))
                             (recur
                              (get-request
                               config
-                              ;; Update Since to the LRS header
+                              ;; Ensure since is updated if it should be
                               (assoc init-params
                                      :since
-                                     consistent-through))
-                             consistent-through))))
+                                     next-since))
+                             next-since))))
                 :exception
                 (do (a/>! out-chan ret)
                     (a/close! out-chan)))))))

--- a/src/lib/com/yetanalytics/xapipe/client.clj
+++ b/src/lib/com/yetanalytics/xapipe/client.clj
@@ -392,11 +392,10 @@
                             (recur
                              (get-request
                               config
-                              ;; Update Since to the LRS header
                               (assoc init-params
                                      :since
-                                     consistent-through))
-                             consistent-through))))
+                                     since))
+                             since))))
                 :exception
                 (do (a/>! out-chan ret)
                     (a/close! out-chan)))))))

--- a/src/lib/com/yetanalytics/xapipe/client.clj
+++ b/src/lib/com/yetanalytics/xapipe/client.clj
@@ -392,10 +392,11 @@
                             (recur
                              (get-request
                               config
+                              ;; Update Since to the LRS header
                               (assoc init-params
                                      :since
-                                     since))
-                             since))))
+                                     consistent-through))
+                             consistent-through))))
                 :exception
                 (do (a/>! out-chan ret)
                     (a/close! out-chan)))))))

--- a/src/lib/com/yetanalytics/xapipe/client.clj
+++ b/src/lib/com/yetanalytics/xapipe/client.clj
@@ -343,7 +343,8 @@
                                            peek
                                            (get "stored")
                                            t/normalize-stamp)
-                      consistent-through (t/normalize-stamp consistent-through-h)]
+                      consistent-through (t/normalize-stamp consistent-through-h)
+                      next-since (or ?last-stored since)]
                   ;; If there are statements, emit them before continuing.
                   ;; This operation will park for takers.
                   (when (not-empty statements)
@@ -368,8 +369,7 @@
                                          config
                                          {} ;; has no effect with more
                                          more)
-                                        ;; Set since for the cursor if we have new stuff
-                                        (or ?last-stored since)))
+                                        next-since))
 
                     ;; The lack of a more link means we are at the end of what the
                     ;; LRS has for the given query.
@@ -386,7 +386,7 @@
                       (a/close! out-chan))
                     ;; With no more link or until, we're polling.
                     ;; Wait for the specified time
-                    :else (let [next-since (or ?last-stored since)]
+                    :else (do
                             (log/debugf "waiting %d ms..." poll-interval)
                             (a/<! (a/timeout poll-interval))
                             (recur


### PR DESCRIPTION
[PIP-50]

While xapipe's cursor only advances on the receipt of data, the GET loop maintains its own cursor, which was pulling ahead according to the consistent-through header. In a perfect world we could trust it, but alas.
This PR explicitly binds a new since which is either the last stored time of a received batch or the previous since.

[PIP-50]: https://yet.atlassian.net/browse/PIP-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ