### PR TITLE
PIP-52 minor metrics refactor

### DIFF
--- a/src/cli/com/yetanalytics/xapipe/metrics/impl/prometheus.clj
+++ b/src/cli/com/yetanalytics/xapipe/metrics/impl/prometheus.clj
@@ -42,14 +42,10 @@
     (reify
       metrics/Reporter
       (-gauge [this k v]
-        (pro/set registry k v)
-        this)
+        (pro/set registry k v))
       (-counter [this k delta]
-        (pro/inc registry k delta)
-        this)
+        (pro/inc registry k delta))
       (-histogram [this k v]
-        (pro/observe registry k v)
-        this)
+        (pro/observe registry k v))
       (-flush! [this]
-        (pro-exp/push! registry)
-        this))))
+        (pro-exp/push! registry)))))

--- a/src/lib/com/yetanalytics/xapipe.clj
+++ b/src/lib/com/yetanalytics/xapipe.clj
@@ -59,8 +59,8 @@
           (metrics/counter :xapipe/all-errors (count (concat
                                                       job-errors
                                                       source-errors
-                                                      target-errors))))
-        (a/thread (metrics/flush! reporter)))
+                                                      target-errors)))
+          metrics/flush!))
       (cond
         (state/errors? state)
         (log/error "POST loop stopping with errors")

--- a/src/lib/com/yetanalytics/xapipe/metrics.clj
+++ b/src/lib/com/yetanalytics/xapipe/metrics.clj
@@ -16,14 +16,10 @@
 
 (deftype NoopReporter []
   Reporter
-  (-gauge [this _ _]
-    this)
-  (-counter [this _ _]
-    this)
-  (-histogram [this _ _]
-    this)
-  (-flush! [this]
-    this))
+  (-gauge [this _ _] nil)
+  (-counter [this _ _] nil)
+  (-histogram [this _ _] nil)
+  (-flush! [this] nil))
 
 (s/def ::reporter
   (s/with-gen #(satisfies? Reporter %)
@@ -42,7 +38,7 @@
   :args (s/cat :reporter ::reporter
                :k ::gauges
                :v number?)
-  :ret ::reporter)
+  :ret any?)
 
 (defn gauge
   "Set a gauge to an arbitrary value"
@@ -65,7 +61,7 @@
   :args (s/cat :reporter ::reporter
                :k ::counters
                :delta nat-int?)
-  :ret ::reporter)
+  :ret any?)
 
 (defn counter
   "Increase a counter by delta"
@@ -83,7 +79,7 @@
   :args (s/cat :reporter ::reporter
                :k ::histograms
                :v number?)
-  :ret ::reporter)
+  :ret any?)
 
 (defn histogram
   "Log an observation of a value"
@@ -92,7 +88,7 @@
 
 (s/fdef flush!
   :args (s/cat :reporter ::reporter)
-  :ret ::reporter)
+  :ret any?)
 
 (defn flush!
   "Flush metrics out if possible"


### PR DESCRIPTION
* Our prometheus client wrapper's examples made it seem like it was immutable and needed to be threaded. It is not/does not. Adapt impls and specs to reflect that
* There were questions about whether the exporter needed to run in a thread, after looking at the upstream source it does not.