### PR TITLE
PIP-54 delete any extra attachments

### DIFF
--- a/src/test/com/yetanalytics/xapipe/xapi_test.clj
+++ b/src/test/com/yetanalytics/xapipe/xapi_test.clj
@@ -2,8 +2,20 @@
   (:require [clojure.test :refer :all]
             [com.yetanalytics.xapipe.xapi :refer :all]
             [com.yetanalytics.xapipe.test-support :as sup]
-            [clojure.spec.test.alpha :as st]))
+            [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as sgen])
+  (:import [java.io File]))
 
 (sup/def-ns-check-tests
   com.yetanalytics.xapipe.xapi
   {:default {sup/stc-opts {:num-tests 10}}})
+
+(deftest response->statements-test
+  (testing "deletes extra attachments"
+    (let [attachment
+          (sgen/generate
+           (s/gen :com.yetanalytics.xapipe.client.multipart-mixed/attachment))]
+      (response->statements {:body
+                             {:statement-result {:statements []}
+                              :attachments [attachment]}})
+      (is (false? (.exists (:tempfile attachment)))))))


### PR DESCRIPTION
[PIP-54] If the source LRS sends us extra attachments, delete them. This shouldn't happen but multipart/mixed impls vary widely

[PIP-54]: https://yet.atlassian.net/browse/PIP-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ