### PR TITLE
PIP-55 catch and log all errors on metrics flush

### DIFF
--- a/src/lib/com/yetanalytics/xapipe.clj
+++ b/src/lib/com/yetanalytics/xapipe.clj
@@ -66,7 +66,7 @@
         (log/error "POST loop stopping with errors")
 
         (not= :running (:status state))
-        (log/error "Stopping")
+        (log/info "Stopping")
 
         :else
         (do

--- a/src/lib/com/yetanalytics/xapipe/metrics.clj
+++ b/src/lib/com/yetanalytics/xapipe/metrics.clj
@@ -2,7 +2,8 @@
   "Metrics protocol called by xapipe lib.
   Inspired by https://github.com/pedestal/pedestal/blob/master/log/src/io/pedestal/log.clj"
   (:require [clojure.spec.alpha :as s]
-            [clojure.spec.gen.alpha :as sgen]))
+            [clojure.spec.gen.alpha :as sgen]
+            [clojure.tools.logging :as log]))
 
 (defprotocol Reporter
   (-gauge [this k v]
@@ -91,6 +92,11 @@
   :ret any?)
 
 (defn flush!
-  "Flush metrics out if possible"
+  "Flush metrics out if possible.
+  Catch all errors and just log them."
   [reporter]
-  (-flush! reporter))
+  (try (-flush! reporter)
+       (catch Exception ex
+         (log/warnf ex
+                    "Metrics flush failed: %s"
+                    (ex-message ex)))))


### PR DESCRIPTION
[PIP-55] If the reporter isn't configured properly, the flush action may throw at runtime. Just warn about this if it happens

[PIP-55]: https://yet.atlassian.net/browse/PIP-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ