### PR TITLE
PIP-57 Don't parse non-200 multipart responses

### DIFF
--- a/src/lib/com/yetanalytics/xapipe/client.clj
+++ b/src/lib/com/yetanalytics/xapipe/client.clj
@@ -18,8 +18,13 @@
 
 ;; Add multipart-mixed output coercion
 (defmethod client/coerce-response-body :multipart/mixed
-  [_ resp]
-  (multipart/parse-response resp))
+  [_ {:keys [status] :as resp}]
+  (if (= 200 status)
+    (multipart/parse-response resp)
+    (do
+      (log/warnf "Received multipart response with non-200 status %d"
+                 status)
+      (update resp :body slurp))))
 
 ;; Config needed for all requests
 (s/def ::url-base


### PR DESCRIPTION
[PIP-57] Our `clj-http` resp handler tries to parse responses as multiparts in some contexts. It should only do that on a 200.

[PIP-57]: https://yet.atlassian.net/browse/PIP-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ