### PR TITLE
PIP-56 Simple JsonPath filter

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -65,6 +65,7 @@ All options:
       --template-id IRI                 []                    Statement template IRIs to filter on
       --pattern-profile-url URL         []                    Profile URL/location from which to apply statement pattern filters
       --pattern-id IRI                  []                    Pattern IRIs to filter on
+      --ensure-path JSONPATH            []                    A JSONPath expression used to filter statements to only those with data at the given path
       --statement-buffer-size SIZE                            Desired size of statement buffer
       --batch-buffer-size SIZE                                Desired size of statement batch buffer
 ```

--- a/doc/options.md
+++ b/doc/options.md
@@ -66,6 +66,7 @@ All options:
       --pattern-profile-url URL         []                    Profile URL/location from which to apply statement pattern filters
       --pattern-id IRI                  []                    Pattern IRIs to filter on
       --ensure-path JSONPATH            []                    A JSONPath expression used to filter statements to only those with data at the given path
+      --match-path JSONPATH=JSON        []                    A JSONPath expression and matching value used to filter statements to only those with data matching the value at the given path
       --statement-buffer-size SIZE                            Desired size of statement buffer
       --batch-buffer-size SIZE                                Desired size of statement batch buffer
 ```

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -117,13 +117,24 @@ bin/run-sh --source-url http://0.0.0.0:8080/xapi \
            --target-username my_key --target-password my_secret \
            --match-path $.verb.id=http://example.com/verb1 \
            --match-path $.verb.id=http://example.com/verb2
+
 ```
 
 Statements with an `$.verb.id` of `http://example.com/verb1` OR `http://example.com/verb2` will be passed.
 
 #### Json Values
 
-WIP
+LRSPipe will attempt to parse path matches as JSON first, then as string. This means you can match a JSON object:
+
+``` shell
+bin/run-sh --source-url http://0.0.0.0:8080/xapi \
+           --target-url http://0.0.0.0:8081/xapi \
+           --job-id path-match-job-2 \
+           --source-username my_key --source-password my_secret \
+           --target-username my_key --target-password my_secret \
+           --match-path $.actor='{"mbox":"mailto:bob@example.com","objectType":"Agent"}'
+
+```
 
 ## Job Management
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -129,7 +129,7 @@ LRSPipe will attempt to parse path matches as JSON first, then as string. This m
 ``` shell
 bin/run-sh --source-url http://0.0.0.0:8080/xapi \
            --target-url http://0.0.0.0:8081/xapi \
-           --job-id path-match-job-2 \
+           --job-id path-match-job-3 \
            --source-username my_key --source-password my_secret \
            --target-username my_key --target-password my_secret \
            --match-path $.actor='{"mbox":"mailto:bob@example.com","objectType":"Agent"}'

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -85,7 +85,45 @@ bin/run-sh --source-url http://0.0.0.0:8080/xapi \
 
 ```
 
-Only statements with a value set at the given [JsonPath String](https://goessner.net/articles/JsonPath/) `$.result.score.scaled` will be passed to the target LRS. This simple filter is useful to ensure the density of an xAPI dataset. To match a value at a given path or to perform negation you should instead use an xAPI Profile with Template and Pattern Filtering (see above).
+Only statements with a value set at the given [JsonPath String](https://goessner.net/articles/JsonPath/) `$.result.score.scaled` will be passed to the target LRS. This simple filter is useful to ensure the density of an xAPI dataset.
+
+If the option is passed multiple times only statements that contain data at ALL paths will be written to the target LRS.
+
+To match a value at a given path see JsonPath Matching below. For more complex filters with features like negation use an xAPI Profile with Template and Pattern Filtering (see above).
+
+### JsonPath Matching
+
+You can apply simple path-matching filters to LRSPipe using the `--match-path` option:
+
+``` shell
+bin/run-sh --source-url http://0.0.0.0:8080/xapi \
+           --target-url http://0.0.0.0:8081/xapi \
+           --job-id path-match-job-1 \
+           --source-username my_key --source-password my_secret \
+           --target-username my_key --target-password my_secret \
+           --match-path $.verb.id=http://example.com/verb
+
+```
+
+Only statements with the value `"http://example.com/verb"` at the path `$.verb.id` will be written to the target LRS.
+
+If the option is given multiple times, a statement must satisfy at least one given value for each path given:
+
+``` shell
+bin/run-sh --source-url http://0.0.0.0:8080/xapi \
+           --target-url http://0.0.0.0:8081/xapi \
+           --job-id path-match-job-2 \
+           --source-username my_key --source-password my_secret \
+           --target-username my_key --target-password my_secret \
+           --match-path $.verb.id=http://example.com/verb1 \
+           --match-path $.verb.id=http://example.com/verb2
+```
+
+Statements with an `$.verb.id` of `http://example.com/verb1` OR `http://example.com/verb2` will be passed.
+
+#### Json Values
+
+WIP
 
 ## Job Management
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -7,7 +7,7 @@ In this section we'll illustrate a few examples of basic usage patterns of LRSPi
 
 ### Start a New Job
 
-In this example we are starting a basic forwarding job with no filters from a source LRS at `0.0.0.0:8080` to a target LRS at `0.0.0.0:8081`. We provide it with a `job-id` which we can reference later in the case that we need to stop, resume, or modify the job. Once initialized this job will forward all existing statements, and then remain active checking for new statements in the source LRS.  
+In this example we are starting a basic forwarding job with no filters from a source LRS at `0.0.0.0:8080` to a target LRS at `0.0.0.0:8081`. We provide it with a `job-id` which we can reference later in the case that we need to stop, resume, or modify the job. Once initialized this job will forward all existing statements, and then remain active checking for new statements in the source LRS.
 
 ``` shell
 bin/run.sh --source-url http://0.0.0.0:8080/xapi \
@@ -70,6 +70,22 @@ bin/run.sh --source-url http://0.0.0.0:8080/xapi \
 ```
 
 As with Template Filtering, the `--pattern-id` flags are optional and further limit the forwarding to only the desired Patterns. If the `--pattern-id` flag is omitted the job will filter on all available Patterns in the Profile.
+
+### JsonPath Presence Filtering
+
+In cases where you want to ensure that every statement posted to the target LRS has data at a given path, use the `--ensure-path` option:
+
+``` shell
+bin/run-sh --source-url http://0.0.0.0:8080/xapi \
+           --target-url http://0.0.0.0:8081/xapi \
+           --job-id path-job-1 \
+           --source-username my_key --source-password my_secret \
+           --target-username my_key --target-password my_secret \
+           --ensure-path $.result.score.scaled
+
+```
+
+Only statements with a value set at [JsonPath String](https://goessner.net/articles/JsonPath/) `$.result.score.scaled` will be passed to the target LRS. This simple filter is useful to ensure the density of an xAPI dataset. To match a value at a given path or to perform negation you should instead use an xAPI Profile with Template and Pattern Filtering (see above).
 
 ## Job Management
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -136,6 +136,8 @@ bin/run-sh --source-url http://0.0.0.0:8080/xapi \
 
 ```
 
+Statements with an `$.actor` matching the fields provided exactly will be passed.
+
 ## Job Management
 
 ### List Persisted Jobs

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -85,7 +85,7 @@ bin/run-sh --source-url http://0.0.0.0:8080/xapi \
 
 ```
 
-Only statements with a value set at [JsonPath String](https://goessner.net/articles/JsonPath/) `$.result.score.scaled` will be passed to the target LRS. This simple filter is useful to ensure the density of an xAPI dataset. To match a value at a given path or to perform negation you should instead use an xAPI Profile with Template and Pattern Filtering (see above).
+Only statements with a value set at the given [JsonPath String](https://goessner.net/articles/JsonPath/) `$.result.score.scaled` will be passed to the target LRS. This simple filter is useful to ensure the density of an xAPI dataset. To match a value at a given path or to perform negation you should instead use an xAPI Profile with Template and Pattern Filtering (see above).
 
 ## Job Management
 

--- a/src/cli/com/yetanalytics/xapipe/cli.clj
+++ b/src/cli/com/yetanalytics/xapipe/cli.clj
@@ -192,6 +192,7 @@
            filter-pattern-profile-urls
            filter-pattern-ids
            filter-ensure-paths
+           filter-match-paths
 
            statement-buffer-size
            batch-buffer-size]}
@@ -240,12 +241,17 @@
     (assoc-in [:filter :template] {:profile-urls filter-template-profile-urls
                                    :template-ids (into []
                                                        filter-template-ids)})
+
     (not-empty filter-pattern-profile-urls)
     (assoc-in [:filter :pattern] {:profile-urls filter-pattern-profile-urls
                                   :pattern-ids (into []
                                                      filter-pattern-ids)})
+
     (not-empty filter-ensure-paths)
-    (assoc-in [:filter :path] {:ensure-paths filter-ensure-paths})))
+    (assoc-in [:filter :path :ensure-paths] filter-ensure-paths)
+
+    (not-empty filter-match-paths)
+    (assoc-in [:filter :path :match-paths] filter-match-paths)))
 
 (s/fdef create-job
   :args (s/cat :options ::opts/all-options)

--- a/src/cli/com/yetanalytics/xapipe/cli.clj
+++ b/src/cli/com/yetanalytics/xapipe/cli.clj
@@ -191,6 +191,7 @@
            filter-template-ids
            filter-pattern-profile-urls
            filter-pattern-ids
+           filter-ensure-paths
 
            statement-buffer-size
            batch-buffer-size]}
@@ -242,7 +243,9 @@
     (not-empty filter-pattern-profile-urls)
     (assoc-in [:filter :pattern] {:profile-urls filter-pattern-profile-urls
                                   :pattern-ids (into []
-                                                     filter-pattern-ids)})))
+                                                     filter-pattern-ids)})
+    (not-empty filter-ensure-paths)
+    (assoc-in [:filter :path] {:ensure-paths filter-ensure-paths})))
 
 (s/fdef create-job
   :args (s/cat :options ::opts/all-options)

--- a/src/cli/com/yetanalytics/xapipe/cli/options.clj
+++ b/src/cli/com/yetanalytics/xapipe/cli/options.clj
@@ -6,7 +6,8 @@
             [clojure.string :as cs]
             [clojure.tools.cli :as cli]
             [com.yetanalytics.xapipe :as xapipe]
-            [com.yetanalytics.xapipe.job.config :as config]))
+            [com.yetanalytics.xapipe.job.config :as config]
+            [com.yetanalytics.xapipe.filter.path :as fpath]))
 
 (defn option-spec->spec-def
   [[short-command long-command desc
@@ -286,6 +287,13 @@
     :multi true
     :default []
     :update-fn conj]
+   [nil "--ensure-path JSONPATH" "A JSONPath expression used to filter statements to only those with data at the given path"
+    :id :filter-ensure-paths
+    :multi true
+    :default []
+    :update-fn (fn [coll v]
+                 (conj coll
+                       (fpath/parse-path v)))]
    [nil "--statement-buffer-size SIZE" "Desired size of statement buffer"
     :parse-fn #(Long/parseLong %)
     :validate [pos-int? "Must be a positive integer"]]
@@ -293,7 +301,7 @@
     :parse-fn #(Long/parseLong %)
     :validate [pos-int? "Must be a positive integer"]]])
 
-(def-option-specs job-options)
+(def-option-specs job-options {::filter-ensure-paths (s/every ::fpath/path)})
 
 (s/def ::all-options
   (s/merge ::common-options

--- a/src/cli/com/yetanalytics/xapipe/cli/options.clj
+++ b/src/cli/com/yetanalytics/xapipe/cli/options.clj
@@ -294,6 +294,20 @@
     :update-fn (fn [coll v]
                  (conj coll
                        (fpath/parse-path v)))]
+   [nil "--match-path JSONPATH=JSON" "A JSONPath expression and matching value used to filter statements to only those with data matching the value at the given path"
+    :id :filter-match-paths
+    :multi true
+    :default []
+    :update-fn
+    (fn [coll v]
+      (let [[path match-str] (cs/split v #"=" 2)
+            ;; Attempt to parse to json, but if you can't it's just a string
+            match-v (try (json/parse-string match-str)
+                         (catch Exception _
+                           match-str))]
+        (conj coll
+              [(fpath/parse-path path)
+               match-v])))]
    [nil "--statement-buffer-size SIZE" "Desired size of statement buffer"
     :parse-fn #(Long/parseLong %)
     :validate [pos-int? "Must be a positive integer"]]
@@ -301,7 +315,8 @@
     :parse-fn #(Long/parseLong %)
     :validate [pos-int? "Must be a positive integer"]]])
 
-(def-option-specs job-options {::filter-ensure-paths (s/every ::fpath/path)})
+(def-option-specs job-options {::filter-ensure-paths ::fpath/ensure-paths
+                               ::filter-match-paths ::fpath/match-paths})
 
 (s/def ::all-options
   (s/merge ::common-options

--- a/src/lib/com/yetanalytics/xapipe/filter.clj
+++ b/src/lib/com/yetanalytics/xapipe/filter.clj
@@ -11,7 +11,8 @@
             [com.yetanalytics.pan.objects.pattern :as pat]
             [com.yetanalytics.pan.objects.profile :as prof]
             [com.yetanalytics.pan.objects.template :as template]
-            [com.yetanalytics.xapipe.client.multipart-mixed :as mm]))
+            [com.yetanalytics.xapipe.client.multipart-mixed :as mm]
+            [com.yetanalytics.xapipe.filter.path :as path]))
 
 (s/def ::profile-url string?) ;; These can be from disk, so don't spec 'em too hard
 (s/def ::template-id ::template/id)
@@ -189,6 +190,7 @@
              false)])
         [state false]))))
 
+(s/def ::path path/path-filter-cfg-spec)
 
 ;; Config map for all filtering
 (def filter-config-spec
@@ -197,17 +199,22 @@
 
 (s/def :com.yetanalytics.xapipe.filter.stateless-predicates/template
   filter-pred-spec)
+(s/def :com.yetanalytics.xapipe.filter.stateless-predicates/path
+  filter-pred-spec)
 
 (s/fdef stateless-predicates
   :args (s/cat :config filter-config-spec)
   :ret (s/keys :opt-un
-               [:com.yetanalytics.xapipe.filter.stateless-predicates/template]))
+               [:com.yetanalytics.xapipe.filter.stateless-predicates/template
+                :com.yetanalytics.xapipe.filter.stateless-predicates/path]))
 
 (defn stateless-predicates
   "Stateless predicates are simple true/false"
-  [{:keys [template]}]
+  [{:keys [template
+           path]}]
   (cond-> {}
-    template (assoc :template (template-filter-pred template))))
+    template (assoc :template (template-filter-pred template))
+    path (assoc :path (path/path-filter-pred path))))
 
 (s/def :com.yetanalytics.xapipe.filter.stateful-predicates/pattern
   pattern-filter-pred-spec)

--- a/src/lib/com/yetanalytics/xapipe/filter/path.clj
+++ b/src/lib/com/yetanalytics/xapipe/filter/path.clj
@@ -1,11 +1,35 @@
 (ns com.yetanalytics.xapipe.filter.path
   "Simple JsonPath-based filtering to ensure dense data."
   (:require [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as sgen]
             [com.yetanalytics.pathetic :as path]
             [com.yetanalytics.pathetic.json-path :as jp]
             [xapi-schema.spec :as xs]))
 
 (s/def ::path ::jp/path)
+
+(s/fdef parse-path
+  :args (s/cat :path-str
+               (s/with-gen string?
+                 (fn []
+                   (sgen/elements
+                    ["$.id"
+                     "$.timestamp"
+                     "$.object.definition.type"
+                     "$.result.duration"
+                     "$.result.success"
+                     "$.result.completion"
+                     "$.result['success', 'completion']"
+                     "$.context.contextActivities.category[*].id"
+                     "$"
+                     "$.foo"]))))
+  :ret ::path)
+
+(defn parse-path
+  "Parse a JsonPath path, ignore any additional paths"
+  [path-str]
+  (first
+   (path/parse-paths path-str)))
 
 (s/def ::ensure-paths (s/every ::path))
 

--- a/src/lib/com/yetanalytics/xapipe/filter/path.clj
+++ b/src/lib/com/yetanalytics/xapipe/filter/path.clj
@@ -1,0 +1,27 @@
+(ns com.yetanalytics.xapipe.filter.path
+  "Simple JsonPath-based filtering to ensure dense data."
+  (:require [clojure.spec.alpha :as s]
+            [com.yetanalytics.pathetic :as path]
+            [com.yetanalytics.pathetic.json-path :as jp]
+            [xapi-schema.spec :as xs]))
+
+(s/def ::path ::jp/path)
+
+(s/def ::ensure-paths (s/every ::path))
+
+(def path-filter-cfg-spec
+  (s/keys :req-un [::ensure-paths]))
+
+(s/fdef path-filter-pred
+  :args (s/cat :config path-filter-cfg-spec)
+  :ret (s/fspec :args (s/cat :record
+                             (s/keys :req-un [::xs/statement]))
+                :ret boolean?))
+
+(defn path-filter-pred
+  [{:keys [ensure-paths]}]
+  (fn [{:keys [statement]}]
+    (every?
+     (fn [path]
+       (not-empty (path/get-paths* statement [path])))
+     ensure-paths)))

--- a/src/test/com/yetanalytics/xapipe/cli/options_test.clj
+++ b/src/test/com/yetanalytics/xapipe/cli/options_test.clj
@@ -100,7 +100,8 @@
            :filter-template-ids [],
            :filter-pattern-profile-urls [],
            :filter-pattern-ids []
-           :filter-ensure-paths []},
+           :filter-ensure-paths []
+           :filter-match-paths []},
           :errors nil}
          (select-keys
           (cli/parse-opts [] job-options)
@@ -132,7 +133,8 @@
    :filter-pattern-ids [],
    :metrics-reporter "noop",
    :prometheus-push-gateway "0.0.0.0:9091"
-   :filter-ensure-paths []})
+   :filter-ensure-paths []
+   :filter-match-paths []})
 
 ;; Matches the fixture job we have
 (def json-job
@@ -223,6 +225,7 @@
     "--statement-buffer-size" "1"
     "--batch-buffer-size" "1"
     "--ensure-path" "$.id"
+    "--match-path" "$.verb.id=http://example.com/verb"
     ]
    {:source-password "bar",
     :filter-pattern-profile-urls ["http://example.org/profile.jsonld"],
@@ -269,5 +272,7 @@
     :target-url "http://0.0.0.0:8081/xapi"
     :metrics-reporter "prometheus"
     :prometheus-push-gateway "localhost:1234"
-    :filter-ensure-paths [[["id"]]]}
+    :filter-ensure-paths [[["id"]]]
+    :filter-match-paths [[[["verb"]["id"]]
+                          "http://example.com/verb"]]}
    []))

--- a/src/test/com/yetanalytics/xapipe/cli/options_test.clj
+++ b/src/test/com/yetanalytics/xapipe/cli/options_test.clj
@@ -99,7 +99,8 @@
            :filter-template-profile-urls [],
            :filter-template-ids [],
            :filter-pattern-profile-urls [],
-           :filter-pattern-ids []},
+           :filter-pattern-ids []
+           :filter-ensure-paths []},
           :errors nil}
          (select-keys
           (cli/parse-opts [] job-options)
@@ -130,7 +131,8 @@
    :list-jobs false,
    :filter-pattern-ids [],
    :metrics-reporter "noop",
-   :prometheus-push-gateway "0.0.0.0:9091"})
+   :prometheus-push-gateway "0.0.0.0:9091"
+   :filter-ensure-paths []})
 
 ;; Matches the fixture job we have
 (def json-job
@@ -220,6 +222,7 @@
     "--pattern-id" "http://example.org/profile.jsonld#foo"
     "--statement-buffer-size" "1"
     "--batch-buffer-size" "1"
+    "--ensure-path" "$.id"
     ]
    {:source-password "bar",
     :filter-pattern-profile-urls ["http://example.org/profile.jsonld"],
@@ -265,5 +268,6 @@
     :conn-default-per-route 1,
     :target-url "http://0.0.0.0:8081/xapi"
     :metrics-reporter "prometheus"
-    :prometheus-push-gateway "localhost:1234"}
+    :prometheus-push-gateway "localhost:1234"
+    :filter-ensure-paths [[["id"]]]}
    []))

--- a/src/test/com/yetanalytics/xapipe/cli/options_test.clj
+++ b/src/test/com/yetanalytics/xapipe/cli/options_test.clj
@@ -226,6 +226,7 @@
     "--batch-buffer-size" "1"
     "--ensure-path" "$.id"
     "--match-path" "$.verb.id=http://example.com/verb"
+    "--match-path" "$.actor={\"mbox\":\"mailto:bob@example.com\",\"objectType\":\"Agent\"}"
     ]
    {:source-password "bar",
     :filter-pattern-profile-urls ["http://example.org/profile.jsonld"],
@@ -274,5 +275,7 @@
     :prometheus-push-gateway "localhost:1234"
     :filter-ensure-paths [[["id"]]]
     :filter-match-paths [[[["verb"]["id"]]
-                          "http://example.com/verb"]]}
+                          "http://example.com/verb"]
+                         [[["actor"]] {"mbox" "mailto:bob@example.com"
+                                       "objectType" "Agent"}]]}
    []))

--- a/src/test/com/yetanalytics/xapipe/filter/path_test.clj
+++ b/src/test/com/yetanalytics/xapipe/filter/path_test.clj
@@ -1,0 +1,19 @@
+(ns com.yetanalytics.xapipe.filter.path-test
+  (:require [clojure.test :refer :all]
+            [com.yetanalytics.xapipe.filter.path :refer :all]
+            [com.yetanalytics.xapipe.test-support :as sup]))
+
+(sup/def-ns-check-tests com.yetanalytics.xapipe.filter.path
+  ;; TODO: These tests are very slow. Investigate pathetic's gens
+  {:default {sup/stc-opts {:num-tests 1}}})
+
+(deftest path-filter-pred-test
+  (let [records (map #(hash-map :statement %)
+                     (sup/gen-statements 50))]
+    (testing "excludes missing"
+      (let [;; Generated statements have no stored
+            pred (path-filter-pred {:ensure-paths [[["stored"]]]})]
+        (is (= [] (filter pred records)))))
+    (testing "includes present"
+      (let [pred (path-filter-pred {:ensure-paths [[["id"]]]})]
+        (is (= records (filter pred records)))))))

--- a/src/test/com/yetanalytics/xapipe/filter/path_test.clj
+++ b/src/test/com/yetanalytics/xapipe/filter/path_test.clj
@@ -12,8 +12,44 @@
                      (sup/gen-statements 50))]
     (testing "excludes missing"
       (let [;; Generated statements have no stored
-            pred (path-filter-pred {:ensure-paths [[["stored"]]]})]
+            pred (path-filter-pred {:ensure-paths [
+                                                   [["stored"]]
+                                                   ]})]
         (is (= [] (filter pred records)))))
     (testing "includes present"
-      (let [pred (path-filter-pred {:ensure-paths [[["id"]]]})]
-        (is (= records (filter pred records)))))))
+      (let [pred (path-filter-pred {:ensure-paths [
+                                                   [["id"]]
+                                                   ]})]
+        (is (= records (filter pred records)))))
+    (testing "include intersection"
+      (let [pred (path-filter-pred {:ensure-paths [
+                                                   [["id"]]
+                                                   [["timestamp"]]
+                                                   ]})]
+        (is (= records (filter pred records)))))
+    (testing "can match"
+      (let [pred (path-filter-pred
+                  {:match-paths [
+                                 [[["id"]]
+                                  "66ff4283-a6ca-439c-b8fe-38ca398271e5"]
+                                 ]})]
+        (is (= 1 (count (filter pred records))))))
+    (testing "can match intersection"
+      (let [pred (path-filter-pred
+                  {:match-paths [
+                                 [[["id"]]
+                                  "66ff4283-a6ca-439c-b8fe-38ca398271e5"]
+                                 [[["verb"]["id"]]
+                                  "https://xapinet.org/xapi/yet/calibration/v1/concepts#didnt"]
+                                 ]})]
+        (is (= 1 (count (filter pred records))))))
+
+    (testing "can match union"
+      (let [pred (path-filter-pred
+                  {:match-paths [
+                                 [[["id"]]
+                                  "66ff4283-a6ca-439c-b8fe-38ca398271e5"]
+                                 [[["id"]]
+                                  "ee309867-15af-4c76-87b4-5fb49d687ee9"]
+                                 ]})]
+        (is (= 2 (count (filter pred records))))))))


### PR DESCRIPTION
[PIP-56] Add a simple JsonPath presence filter that ensures that only statements with a value at the given path will be passed

See updated docs here: https://github.com/yetanalytics/xapipe/blob/PIP-56/doc/usage.md#jsonpath-presence-filtering and here: https://github.com/yetanalytics/xapipe/blob/PIP-56/doc/usage.md#jsonpath-matching and here: https://github.com/yetanalytics/xapipe/blob/PIP-56/doc/options.md

[PIP-56]: https://yet.atlassian.net/browse/PIP-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ