### PR TITLE
PIP-60 Throughput benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ failures/
 /store/
 /.test_store/
 /tmp/
+/dev-resources/bench/*.json

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 .phony: test-lib bench clean bundle bundle-help
 
 clean:
-	rm -rf target
+	rm -rf target dev-resources/bench/*.json
 
 test-lib:
 	clojure -X:cli:test :dirs '["src/test"]'
 
-bench:
+dev-resources/bench/payload.json:
+	clojure -Xtest:bench write-payload
+
+bench: dev-resources/bench/payload.json
 	clojure -Xtest:bench
 
 target/bundle/xapipe.jar:

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,19 @@ clean:
 test-lib:
 	clojure -X:cli:test :dirs '["src/test"]'
 
+BENCH_SIZE ?= 10000
+BENCH_PROFILE ?= dev-resources/profiles/calibration.jsonld
+
 dev-resources/bench/payload.json:
-	clojure -Xtest:bench write-payload
+	clojure -Xtest:bench write-payload \
+		:num-statements $(BENCH_SIZE) \
+		:profile '"$(BENCH_PROFILE)"' \
+		:out '"dev-resources/bench/payload.json"'
 
 bench: dev-resources/bench/payload.json
-	clojure -Xtest:bench
+	clojure -Xtest:bench run-bench \
+		:num-statements $(BENCH_SIZE) \
+		:payload-path '"dev-resources/bench/payload.json"'
 
 target/bundle/xapipe.jar:
 	clojure -T:build uber

--- a/deps.edn
+++ b/deps.edn
@@ -29,7 +29,8 @@
 
                      clj-commons/iapetos {:mvn/version "0.1.12"}
                      io.prometheus/simpleclient_hotspot {:mvn/version "0.12.0"}}}
-  :test {:extra-paths ["src/test"]
+  :test {:extra-paths ["src/test"
+                       "src/bench"]
          :extra-deps {org.clojure/test.check {:mvn/version "1.1.0"}
                       io.github.cognitect-labs/test-runner
                       {:git/url "https://github.com/cognitect-labs/test-runner"

--- a/deps.edn
+++ b/deps.edn
@@ -53,8 +53,7 @@
                                     com.yetanalytics/xapi-schema]}}
          :exec-fn cognitect.test-runner.api/test}
   :bench {:extra-paths ["src/bench"]
-          :ns-default com.yetanalytics.xapipe.bench
-          :exec-fn run-bench}
+          :ns-default com.yetanalytics.xapipe.bench}
   :build {:paths ["src/build"]
           :deps {io.github.clojure/tools.build {:git/tag "v0.6.6" :git/sha "4d41c26"}}
           :ns-default com.yetanalytics.xapipe.build}}}

--- a/src/bench/com/yetanalytics/xapipe/bench.clj
+++ b/src/bench/com/yetanalytics/xapipe/bench.clj
@@ -3,18 +3,122 @@
             [com.yetanalytics.xapipe :as xapipe]
             [clojure.core.async :as a]
             [clojure.pprint :as pprint]
-            [com.yetanalytics.xapipe.bench.maths :as maths]))
+            [com.yetanalytics.xapipe.bench.maths :as maths]
+            [cheshire.core :as json]
+            [clojure.java.io :as io]
+            [com.yetanalytics.xapipe.util.time :as tu]
+            [java-time :as t]
+            [java-time.seqs :as tseq]))
 
-(defn run-bench [{:keys [runs
-                         warmup
-                         seed-path
+(defn- stamp-seq
+  "Create a lazy sequence of timestamps"
+  []
+  (map
+   tu/normalize-inst
+   (tseq/iterate
+    t/plus
+    (t/instant)
+    (t/millis 1))))
+
+(defn write-payload
+  "Write a large number of statements to disk"
+  [{:keys [num-statements
+           profile
+           seed
+           out]
+    :or {num-statements 10000
+         profile "dev-resources/profiles/calibration.jsonld"
+         seed 42
+         out "dev-resources/bench/payload.json"}}]
+  (with-open [w (io/writer out)]
+    (doseq [s (map
+               (fn [stored s]
+                 (assoc s "stored" stored))
+               (stamp-seq)
+               (sup/gen-statements
+                num-statements
+                :profiles
+                [profile]
+                :parameters {:seed seed}))]
+      (json/generate-stream s w))))
+
+(defn run-lrs
+  [{:keys [path]
+    :or {path "dev-resources/bench/payload.json"}}]
+  (let [lrs (sup/lrs
+             :stream-path path
+             :port 8080)]
+    ((:start lrs))))
+
+(defn run-bench [{:keys [payload-path
                          source-port
-                         target-port]
-                  :or {runs 100
-                       warmup 10
-                       seed-path "dev-resources/lrs/after_conf.edn"
+                         target-port
+                         total-statements]
+                  :or {payload-path "dev-resources/bench/payload.json"
                        source-port 8080
-                       target-port 8081}}]
+                       target-port 8081
+                       total-statements 10000}}]
+  (printf "\nInitializing source LRS from %s\n\n" payload-path)
+  (sup/with-running [source (sup/lrs
+                             :stream-path payload-path
+                             :port source-port)
+                     target (sup/lrs
+                             :sink true
+                             :port target-port)]
+    (let [[since until] (sup/lrs-stored-range source)
+          job-id (.toString (java.util.UUID/randomUUID))
+          job {:id job-id,
+               :config
+               {:source
+                {:request-config
+                 {:url-base (format "http://0.0.0.0:%d"
+                                    source-port),
+                  :xapi-prefix "/xapi"},
+                 :get-params
+                 {:since since
+                  :until until}},
+                :target
+                {:request-config
+                 {:url-base (format "http://0.0.0.0:%d"
+                                    target-port),
+                  :xapi-prefix "/xapi"}}},
+               :state
+               {:status :init,
+                :cursor "1970-01-01T00:00:00.000000000Z",
+                :source {:errors []},
+                :target {:errors []},
+                :errors [],
+                :filter {}}}
+          t-before (System/currentTimeMillis)
+          ;; Run the job
+          all-states (a/<!! (a/into []
+                                    (:states (xapipe/run-job job))))
+          t-after (System/currentTimeMillis)
+          _ (when (-> all-states last :state :status (= :error))
+              (throw (ex-info "Job Error!"
+                              {:type ::job-error
+                               :state (:state (last all-states))})))
+
+          total-ms (- t-after t-before)
+          s-per-sec (double
+                     (* 1000
+                        (/ total-statements
+                           total-ms)))]
+      (pprint/print-table
+       [{"s/sec throughput" s-per-sec}]))))
+
+(defn run-conf-bench
+  "Older bench based on running conformance results through"
+  [{:keys [runs
+           warmup
+           seed-path
+           source-port
+           target-port]
+    :or {runs 100
+         warmup 10
+         seed-path "dev-resources/lrs/after_conf.edn"
+         source-port 8080
+         target-port 8081}}]
   (assert (< 1 runs) "Must run at least once")
   (assert (nat-int? warmup) "Negative warmup doesn't make sense")
   (printf "\nInitializing source LRS from %s\n\n" seed-path)

--- a/src/bench/com/yetanalytics/xapipe/bench.clj
+++ b/src/bench/com/yetanalytics/xapipe/bench.clj
@@ -43,21 +43,21 @@
       (json/generate-stream s w))))
 
 (defn run-lrs
-  [{:keys [path]
-    :or {path "dev-resources/bench/payload.json"}}]
+  [{:keys [payload-path]
+    :or {payload-path "dev-resources/bench/payload.json"}}]
   (let [lrs (sup/lrs
-             :stream-path path
+             :stream-path payload-path
              :port 8080)]
     ((:start lrs))))
 
 (defn run-bench [{:keys [payload-path
                          source-port
                          target-port
-                         total-statements]
+                         num-statements]
                   :or {payload-path "dev-resources/bench/payload.json"
                        source-port 8080
                        target-port 8081
-                       total-statements 10000}}]
+                       num-statements 10000}}]
   (printf "\nInitializing source LRS from %s\n\n" payload-path)
   (sup/with-running [source (sup/lrs
                              :stream-path payload-path
@@ -102,7 +102,7 @@
           total-ms (- t-after t-before)
           s-per-sec (double
                      (* 1000
-                        (/ total-statements
+                        (/ num-statements
                            total-ms)))]
       (pprint/print-table
        [{"s/sec throughput" s-per-sec}]))))

--- a/src/bench/com/yetanalytics/xapipe/bench.clj
+++ b/src/bench/com/yetanalytics/xapipe/bench.clj
@@ -8,7 +8,8 @@
             [clojure.java.io :as io]
             [com.yetanalytics.xapipe.util.time :as tu]
             [java-time :as t]
-            [java-time.seqs :as tseq]))
+            [java-time.seqs :as tseq])
+  (:import [java.time Instant]))
 
 (defn- stamp-seq
   "Create a lazy sequence of timestamps"
@@ -43,12 +44,21 @@
       (json/generate-stream s w))))
 
 (defn run-lrs
+  "Run an LRS that will stream out statements from a file"
   [{:keys [payload-path]
     :or {payload-path "dev-resources/bench/payload.json"}}]
   (let [lrs (sup/lrs
              :stream-path payload-path
              :port 8080)]
     ((:start lrs))))
+
+
+(defn- job-time-ms
+  "Derive total job time in ms from run states"
+  [states]
+  (-
+   (-> states last :state :updated tu/parse-inst inst-ms)
+   (-> states first :state :updated tu/parse-inst inst-ms)))
 
 (defn run-bench [{:keys [payload-path
                          source-port
@@ -89,136 +99,20 @@
                 :target {:errors []},
                 :errors [],
                 :filter {}}}
-          t-before (System/currentTimeMillis)
           ;; Run the job
-          all-states (a/<!! (a/into []
-                                    (:states (xapipe/run-job job))))
-          t-after (System/currentTimeMillis)
+          all-states (a/<!! (a/into [] (:states (xapipe/run-job job))))
+          ;; _ (pprint/pprint {:job-states (mapv :state all-states)})
           _ (when (-> all-states last :state :status (= :error))
               (throw (ex-info "Job Error!"
                               {:type ::job-error
                                :state (:state (last all-states))})))
 
-          total-ms (- t-after t-before)
+          total-ms (job-time-ms all-states)
           s-per-sec (double
                      (* 1000
                         (/ num-statements
                            total-ms)))]
       (pprint/print-table
-       [{"s/sec throughput" s-per-sec}]))))
-
-(defn run-conf-bench
-  "Older bench based on running conformance results through"
-  [{:keys [runs
-           warmup
-           seed-path
-           source-port
-           target-port]
-    :or {runs 100
-         warmup 10
-         seed-path "dev-resources/lrs/after_conf.edn"
-         source-port 8080
-         target-port 8081}}]
-  (assert (< 1 runs) "Must run at least once")
-  (assert (nat-int? warmup) "Negative warmup doesn't make sense")
-  (printf "\nInitializing source LRS from %s\n\n" seed-path)
-  (sup/with-running [source (sup/lrs
-                             :seed-path seed-path
-                             :port source-port)
-                     target (sup/lrs
-                             :sink true
-                             :port target-port)]
-    (let [[since until] (sup/lrs-stored-range source)
-          source-count (sup/lrs-count source)
-          total-statements (* runs source-count)
-          job-id (.toString (java.util.UUID/randomUUID))
-          base-job {:id job-id,
-                    :config
-                    {:source
-                     {:request-config
-                      {:url-base (format "http://0.0.0.0:%d"
-                                         source-port),
-                       :xapi-prefix "/xapi"},
-                      :get-params
-                      {:since since
-                       :until until}},
-                     :target
-                     {:request-config
-                      {:xapi-prefix "/xapi"}}},
-                    :state
-                    {:status :init,
-                     :cursor "1970-01-01T00:00:00.000000000Z",
-                     :source {:errors []},
-                     :target {:errors []},
-                     :errors [],
-                     :filter {}}}
-          _ (printf "Benching with %d runs for a total of %d statements after %d run warmup...\n\n"
-                    runs
-                    total-statements
-                    warmup)
-          _ (println "Starting warmup...")
-          results (drop warmup
-                        (doall
-                         (for [idx (range (+ warmup runs))
-                               :let [_ (when (= (dec warmup) idx)
-                                         (println "...warmup complete")
-                                         (flush))]]
-                           (let [job (assoc-in base-job
-                                               [:config
-                                                :target
-                                                :request-config
-                                                :url-base]
-                                               (format "http://0.0.0.0:%d"
-                                                       target-port))
-                                 t-before (System/currentTimeMillis)
-                                 ;; Run the job
-                                 all-states (a/<!! (a/into []
-                                                           (:states (xapipe/run-job job))))
-                                 t-after (System/currentTimeMillis)]
-                             (when (-> all-states last :state :status (= :error))
-                               (throw (ex-info "Job Error!"
-                                               {:type ::job-error
-                                                :state (:state (last all-states))})))
-                             (when (<= warmup idx)
-                               (print "#")
-                               (let [run-idx (- idx
-                                                warmup)]
-                                 (when (and (not (zero? run-idx))
-                                            (zero? (rem run-idx
-                                                        80)))
-                                   (print "\n")))
-                               (flush))
-
-                             {:idx idx
-                              :t-before t-before
-                              :t-after t-after}))))
-          _ (print "\n")
-          ts-ms (for [{:keys [t-before
-                              t-after]} results]
-                  (- t-after t-before))
-          [min'
-           max'
-           mean
-           median
-           stddev
-           sum] ((juxt
-                  #(reduce min %)
-                  #(reduce max %)
-                  maths/mean
-                  maths/median
-                  #(maths/stddev
-                    %
-                    :complete-population? true)
-                  #(reduce + %))
-                 ts-ms)]
-      (pprint/print-table
-       [{"min (ms)" min'
-         "max (ms)" max'
-         "mean (ms)" mean
-         "median (ms)" median
-         "stdev (ms)" stddev
-         "s/sec throughput"
-         (double
-          (* 1000
-             (/ total-statements
-                sum)))}]))))
+       [{"statements" num-statements
+         "total time (ms)" total-ms
+         "s/sec throughput" s-per-sec}]))))

--- a/src/bench/com/yetanalytics/xapipe/bench.clj
+++ b/src/bench/com/yetanalytics/xapipe/bench.clj
@@ -43,15 +43,25 @@
                 :parameters {:seed seed}))]
       (json/generate-stream s w))))
 
-(defn run-lrs
+(defn run-source-lrs
   "Run an LRS that will stream out statements from a file"
-  [{:keys [payload-path]
-    :or {payload-path "dev-resources/bench/payload.json"}}]
+  [{:keys [payload-path
+           port]
+    :or {payload-path "dev-resources/bench/payload.json"
+         port 8080}}]
   (let [lrs (sup/lrs
              :stream-path payload-path
-             :port 8080)]
+             :port port)]
     ((:start lrs))))
 
+(defn run-target-lrs
+  "Run a dummy LRS that will accept statements but not store them"
+  [{:keys [port]
+    :or {port 8081}}]
+  (let [lrs (sup/lrs
+             :sink true
+             :port port)]
+    ((:start lrs))))
 
 (defn- job-time-ms
   "Derive total job time in ms from run states"

--- a/src/lib/com/yetanalytics/xapipe.clj
+++ b/src/lib/com/yetanalytics/xapipe.clj
@@ -79,9 +79,13 @@
                 ;; A stop is called!
                 (case status
                   :paused
-                  (recur (state/set-status state :paused))
+                  (recur (-> state
+                             (state/set-status :paused)
+                             state/set-updated))
                   :error
-                  (recur (state/add-error state error))))
+                  (recur (-> state
+                             (state/add-error error)
+                             state/set-updated))))
               (if-some [{:keys [batch
                                 filter-state]
                          :or {filter-state {}}} v]
@@ -124,7 +128,8 @@
                            (count attachments)))
                         (recur (-> state
                                    (state/update-cursor cursor)
-                                   (state/update-filter filter-state))))
+                                   (state/update-filter filter-state)
+                                   state/set-updated)))
                       ;; If the post fails, Send the error to the stop channel
                       ;; emit and stop.
                       :exception
@@ -138,7 +143,9 @@
                           (a/>! stop-chan {:status :error
                                            :error error})
                           (log/error "Stopping on POST error")
-                          (recur (state/add-error state error)))))))
+                          (recur (-> state
+                                     (state/add-error error)
+                                     state/set-updated)))))))
                 ;; Job finishes
                 ;; Might still be from pause/stop
                 (if-some [stop-data (a/poll! stop-chan)]
@@ -149,7 +156,9 @@
                   ;; Otherwise we are complete!
                   (do
                     (log/info "Successful Completion")
-                    (recur (state/set-status state :complete))))))))))
+                    (recur (-> state
+                               (state/set-status :complete)
+                               state/set-updated))))))))))
     ;; Post-loop, kill the HTTP client and close the states chan
     (client/shutdown conn-mgr)
     (.close ^CloseableHttpClient http-client)
@@ -311,7 +320,9 @@
             ;; Send the init state
             _ (a/put! states-chan job-before)
             ;; Then set it as running for post
-            running-state (state/set-status state-before :running)]
+            running-state (-> state-before
+                              (state/set-status :running)
+                              state/set-updated)]
         ;; Post loop transfers statements until it reaches until or an error
         (post-loop
          (merge job-before

--- a/src/lib/com/yetanalytics/xapipe.clj
+++ b/src/lib/com/yetanalytics/xapipe.clj
@@ -253,6 +253,10 @@
                         (last (sort [cursor-before
                                      ?query-since]))
                         cursor-before)
+
+            ;; Send the initial state
+            _ (a/put! states-chan
+                      (update job-before :state state/set-updated))
             ;; A channel that will produce get responses
             get-chan (client/get-chan
                       (a/chan
@@ -317,8 +321,6 @@
                (when (not-empty attachments)
                  (a/thread (mm/clean-tempfiles! attachments))))
              :reporter reporter)
-            ;; Send the init state
-            _ (a/put! states-chan job-before)
             ;; Then set it as running for post
             running-state (-> state-before
                               (state/set-status :running)

--- a/src/lib/com/yetanalytics/xapipe/job/state.clj
+++ b/src/lib/com/yetanalytics/xapipe/job/state.clj
@@ -37,13 +37,17 @@
     (fn []
       (sgen/return {}))))
 
+(s/def ::updated ::t/normalized-stamp)
+
 (def state-spec
   (s/keys :req-un [::source
                    ::target
                    ::errors
                    ::cursor
                    ::status
-                   ::filter]))
+                   ::filter]
+          ;; Timestamp is added/replaced at runtime
+          :opt-un [::updated]))
 
 (s/fdef errors?
   :args (s/cat :state state-spec)
@@ -207,3 +211,12 @@
                {:type :job
                 :message "Cannot update filter on job with errors"})
     (assoc state :filter filter-state)))
+
+(s/fdef set-updated
+  :args (s/cat :state state-spec)
+  :ret (s/and state-spec
+              #(:updated %)))
+
+(defn set-updated
+  [state]
+  (assoc state :updated (t/now-stamp)))

--- a/src/lib/com/yetanalytics/xapipe/util/time.clj
+++ b/src/lib/com/yetanalytics/xapipe/util/time.clj
@@ -116,3 +116,12 @@
           ;; the platform lib. In clojure instants are precise so we can just do
           ;; it. In cljs, we need to override it
           (normalize-inst (parse-inst timestamp)))))))
+
+(s/fdef now-stamp
+  :args (s/cat)
+  :ret ::normalized-stamp)
+
+(defn now-stamp
+  "Return the current time as a normalized stamp"
+  []
+  (normalize-inst (Instant/now)))

--- a/src/test/com/yetanalytics/xapipe/main_test.clj
+++ b/src/test/com/yetanalytics/xapipe/main_test.clj
@@ -115,7 +115,7 @@
                 :target {:errors []},
                 :errors [],
                 :filter {}}}}
-             (mem/dump store)))
+             (update-in (mem/dump store) [job-id :state] dissoc :updated)))
       ;; Resume from cli
       (testing "xapipe resumes a paused job"
         (let [job-id (-> tail-states last :id)]
@@ -203,7 +203,7 @@
                 :target {:errors [{:type :target, :message "Max retries reached: Connection refused"}]},
                 :errors [],
                 :filter {}}}}
-             (mem/dump store)))
+             (update-in (mem/dump store) [job-id :state] dissoc :updated)))
       (with-redefs [cli/create-store (constantly store)]
         (testing "xapipe normally can't resume with errors"
           (is (= 1
@@ -342,7 +342,9 @@
                        :filter {}},
                       :get-buffer-size 10,
                       :batch-timeout 200}
-                     (edn/read-string message)))))))
+                     (update
+                      (edn/read-string message)
+                      :state dissoc :updated)))))))
       (finally
         (.delete ^File (io/file ".test_store/foo.edn"))
         (.delete ^File (io/file ".test_store"))))))

--- a/src/test/com/yetanalytics/xapipe/test_support/lrs.clj
+++ b/src/test/com/yetanalytics/xapipe/test_support/lrs.clj
@@ -2,7 +2,10 @@
   "LRS and LRS Facade facilities"
   (:require [com.yetanalytics.lrs.protocol :as lrsp]
             [com.yetanalytics.lrs.xapi.statements :as ss]
-            [com.yetanalytics.lrs.xapi.statements.timestamp :as timestamp]))
+            [com.yetanalytics.lrs.xapi.statements.timestamp :as timestamp]
+            [cheshire.core :as json]
+            [clojure.java.io :as io]
+            [com.yetanalytics.lrs.util :as lrsu]))
 
 ;; An LRS that accepts statements but does not retain them
 (deftype SinkLRS []
@@ -27,3 +30,60 @@
       :auth   {:no-op {}}}})
   (-authorize [_ _ _]
     {:result true}))
+
+(defn- make-more-url
+  [xapi-path-prefix params last-id agent]
+  (str xapi-path-prefix
+       "/statements?"
+       (lrsu/form-encode
+        (cond-> params
+          true (assoc :from last-id)
+          ;; Re-encode the agent if present
+          agent (assoc :agent (lrsu/json-string agent))))))
+
+(defn stream-lrs
+  "Create a read-only LRS that ignores all params except limit and streams
+  statements from a json file"
+  [path & {:keys [xapi-prefix]
+           :or {xapi-prefix "/xapi"}}]
+  (let [ss-atom (atom (json/parsed-seq (io/reader path)))]
+    (reify
+      lrsp/StatementsResource
+      (-get-statements [_
+                        _
+                        {:keys [limit]
+                         :or {limit 50}}
+                        _]
+        (let [[batch rest-ss] (split-at limit @ss-atom)]
+          (reset! ss-atom rest-ss)
+          {:attachments []
+           :statement-result
+           (cond-> {:statements []}
+             (not-empty batch)
+             (update :statements into batch)
+
+             (not-empty rest-ss)
+             (assoc :more
+                    (str xapi-prefix
+                         "/statements?"
+                         (lrsu/form-encode
+                          {:limit limit
+                           :attachments true}))))}))
+
+      (-consistent-through [_ _ _]
+        (ss/now-stamp))
+      lrsp/LRSAuth
+      (-authenticate [_ _]
+        {:result
+         {:scopes #{:scope/all}
+          :prefix ""
+          :auth   {:no-op {}}}})
+      (-authorize [_ _ _]
+        {:result true}))))
+
+(defn get-stream-lrs-range
+  "Get the stored range of a large JSON file"
+  [path]
+  (let [ss (json/parsed-seq (io/reader path))]
+    [(-> ss first (get "stored"))
+     (-> ss last (get "stored"))]))

--- a/src/test/com/yetanalytics/xapipe_test.clj
+++ b/src/test/com/yetanalytics/xapipe_test.clj
@@ -230,8 +230,12 @@
                                 :source {:errors []}
                                 :target {:errors []}
                                 :filter {}})
-                 (a/<!! (store-states states store))
-                 (store/read-job store job-id))))))))
+                 (update
+                  (a/<!! (store-states states store))
+                  :state dissoc :updated)
+                 (update
+                  (store/read-job store job-id)
+                  :state dissoc :updated))))))))
 
 (deftest resume-test
   (sup/with-running [source (sup/lrs


### PR DESCRIPTION
[PIP-60] Devise a benchmark solely concerned with statement throughput

The new benchmark will:
1. Create a JSON payload of statements
2. Stream those statements out of a facade LRS

Like so:

```shell
$ make clean bench

rm -rf target dev-resources/bench/*.json
clojure -Xtest:bench write-payload \
		:num-statements 10000 \
		:profile '"dev-resources/profiles/calibration.jsonld"' \
		:out '"dev-resources/bench/payload.json"'
clojure -Xtest:bench run-bench \
		:num-statements 10000 \
		:payload-path '"dev-resources/bench/payload.json"'

Initializing source LRS from dev-resources/bench/payload.json


| statements | total time (ms) |  s/sec throughput |
|------------+-----------------+-------------------|
|      10000 |            3164 | 3160.556257901391 |
```

Also adds an `:updated` timestamp to the job state, which is updated on every state change

[PIP-60]: https://yet.atlassian.net/browse/PIP-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ