### PR TITLE
PIP-63 Restrict Java Modules in Test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,5 +17,5 @@ jobs:
           key: ${{ runner.os }}-deps-${{ hashFiles('deps.edn') }}
           restore-keys: |
             ${{ runner.os }}-deps-
-      - name: Test lib
-        run: make test-lib
+      - name: Run Tests
+        run: make test

--- a/.java_modules
+++ b/.java_modules
@@ -1,1 +1,1 @@
-java.base,java.logging,java.naming,java.sql,java.management
+java.base,java.logging,java.naming,java.sql,java.management,jdk.crypto.ec

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@
 clean:
 	rm -rf target dev-resources/bench/*.json
 
+JAVA_MODULES ?= $(shell cat .java_modules)
+
 test:
-	clojure -X:cli:test :dirs '["src/test"]'
+	clojure -J--limit-modules -J$(JAVA_MODULES) -X:cli:test :dirs '["src/test"]'
 
 BENCH_SIZE ?= 10000
 BENCH_PROFILE ?= dev-resources/profiles/calibration.jsonld
@@ -31,7 +33,6 @@ target/bundle/bin:
 # Make Runtime Environment (i.e. JREs)
 # Will only produce a single jre for macos/linux matching your machine
 MACHINE ?= $(shell bin/machine.sh)
-JAVA_MODULES ?= $(shell cat .java_modules)
 
 target/bundle/runtimes:
 	mkdir -p target/bundle/runtimes

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-.phony: test-lib bench clean bundle bundle-help
+.phony: test bench clean bundle bundle-help
 
 clean:
 	rm -rf target dev-resources/bench/*.json
 
-test-lib:
+test:
 	clojure -X:cli:test :dirs '["src/test"]'
 
 BENCH_SIZE ?= 10000

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -2,4 +2,4 @@
 
 MACHINE=`bin/machine.sh`
 
-runtimes/$MACHINE/bin/java -server -Dhttps.protocols=TLSv1.2 -jar xapipe.jar $@
+runtimes/$MACHINE/bin/java -server -jar xapipe.jar $@

--- a/src/test/com/yetanalytics/xapipe/filter_test.clj
+++ b/src/test/com/yetanalytics/xapipe/filter_test.clj
@@ -13,9 +13,14 @@
 
 (deftest get-profile-test
   (testing "slurps the profile from wherever"
-    (is
-     (s/valid? ::prof/profile
-               (get-profile "dev-resources/profiles/calibration.jsonld")))))
+    (testing "a local file"
+      (is
+       (s/valid? ::prof/profile
+                 (get-profile "dev-resources/profiles/calibration.jsonld"))))
+    (testing "a remote file via https"
+      (is
+       (s/valid? ::prof/profile
+                 (get-profile "https://raw.githubusercontent.com/yetanalytics/xapipe/925a16340a1c7f568b98b6d39d88d2e446ea87d5/dev-resources/profiles/calibration.jsonld"))))))
 
 (deftest template-filter-xf-test
   (let [;; Turn into a transducer to show sequence behavior


### PR DESCRIPTION
We've been testing with whatever modules the dev has laying around on their machine. To be closer to the custom runtime we can restrict the modules used when running tests.

Update: Adding `jvm.crypto.ec` as mentioned in https://stackoverflow.com/questions/68896945/javax-net-ssl-sslhandshakeexception-happening-when-using-custom-java-runtime-ima allows TLS 1.3 or 1.2 without issue.