### PR TITLE
PIP-65 Bug: settings provided for restarted jobs are ignored

### DIFF
--- a/src/cli/com/yetanalytics/xapipe/cli.clj
+++ b/src/cli/com/yetanalytics/xapipe/cli.clj
@@ -447,17 +447,17 @@
 
     (not= get-buffer-size
           (get job :get-buffer-size))
-    (assoc :get-buffer-size get-buffer-size)
+    (assoc-in [:config :get-buffer-size] get-buffer-size)
 
     (not= batch-timeout
           (get job :batch-timeout))
-    (assoc :batch-timeout batch-timeout)
+    (assoc-in [:config :batch-timeout] batch-timeout)
 
     statement-buffer-size
-    (assoc :statement-buffer-size statement-buffer-size)
+    (assoc-in [:config :statement-buffer-size] statement-buffer-size)
 
     batch-buffer-size
-    (assoc :batch-buffer-size batch-buffer-size)))
+    (assoc-in [:config :batch-buffer-size] batch-buffer-size)))
 
 (s/fdef list-store-jobs
   :args (s/cat :store :com.yetanalytics.xapipe/store)

--- a/src/test/com/yetanalytics/xapipe/cli_test.clj
+++ b/src/test/com/yetanalytics/xapipe/cli_test.clj
@@ -160,45 +160,8 @@
            :batch-buffer-size 100}))))
 
 (deftest reconfigure-job-test
-  (is (= {:id "foo",
-          :config
-          {:get-buffer-size 100,
-           :statement-buffer-size 1000,
-           :batch-buffer-size 100,
-           :batch-timeout 200,
-           :source
-           {:request-config
-            {:url-base "http://0.0.0.0:8082",
-             :xapi-prefix "/xapi2",
-             :username "baz",
-             :password "quxx"},
-            :get-params {:format "exact"},
-            :poll-interval 3000,
-            :batch-size 100,
-            :backoff-opts
-            {:budget 999, :max-attempt 9, :j-range 9, :initial 2}},
-           :target
-           {:request-config
-            {:url-base "http://0.0.0.0:8083",
-             :xapi-prefix "/xapi2",
-             :username "baz",
-             :password "quxx"},
-            :batch-size 100,
-            :backoff-opts
-            {:budget 999, :max-attempt 9, :j-range 9, :initial 2}},
-           :filter {}},
-          :state
-          {:status :init,
-           :cursor "1970-01-01T00:00:00.000000000Z",
-           :source {:errors []},
-           :target {:errors []},
-           :errors [],
-           :filter {}},
-          :get-buffer-size 200,
-          :batch-timeout 300,
-          :statement-buffer-size 10000,
-          :batch-buffer-size 1000}
-         (reconfigure-job
+  (let [reconfigured
+        (reconfigure-job
           {:id "foo",
            :config
            {:get-buffer-size 100,
@@ -258,4 +221,39 @@
            :batch-timeout 300
 
            :statement-buffer-size 10000
-           :batch-buffer-size 1000}))))
+           :batch-buffer-size 1000})]
+    (is (= {:id "foo",
+            :config
+            {:get-buffer-size 200,
+             :batch-timeout 300,
+             :statement-buffer-size 10000,
+             :batch-buffer-size 1000
+             :source
+             {:request-config
+              {:url-base "http://0.0.0.0:8082",
+               :xapi-prefix "/xapi2",
+               :username "baz",
+               :password "quxx"},
+              :get-params {:format "exact"},
+              :poll-interval 3000,
+              :batch-size 100,
+              :backoff-opts
+              {:budget 999, :max-attempt 9, :j-range 9, :initial 2}},
+             :target
+             {:request-config
+              {:url-base "http://0.0.0.0:8083",
+               :xapi-prefix "/xapi2",
+               :username "baz",
+               :password "quxx"},
+              :batch-size 100,
+              :backoff-opts
+              {:budget 999, :max-attempt 9, :j-range 9, :initial 2}},
+             :filter {}},
+            :state
+            {:status :init,
+             :cursor "1970-01-01T00:00:00.000000000Z",
+             :source {:errors []},
+             :target {:errors []},
+             :errors [],
+             :filter {}}}
+           reconfigured))))

--- a/src/test/com/yetanalytics/xapipe/main_test.clj
+++ b/src/test/com/yetanalytics/xapipe/main_test.clj
@@ -339,9 +339,7 @@
                        :source {:errors []},
                        :target {:errors []},
                        :errors [],
-                       :filter {}},
-                      :get-buffer-size 10,
-                      :batch-timeout 200}
+                       :filter {}}}
                      (update
                       (edn/read-string message)
                       :state dissoc :updated)))))))


### PR DESCRIPTION
[PIP-65] The assoc path was incorrect, meaning the buffer + batch timeout settings would get dropped

[PIP-65]: https://yet.atlassian.net/browse/PIP-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ