### PR TITLE
bump version of NVD in scheduled scan

### DIFF
--- a/.github/workflows/nvd_sched.yml
+++ b/.github/workflows/nvd_sched.yml
@@ -8,4 +8,5 @@ jobs:
   nvd_scan:
     uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.1
     with:
+      nvd-clojure-version: '2.0.0'
       classpath-command: 'clojure -Spath -A:cli'


### PR DESCRIPTION
Because later is better.