### PR TITLE
NVD scan update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,11 @@ jobs:
         run: make test
 
   nvd_scan:
-    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.2
+    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.3
     with:
       nvd-clojure-version: '2.0.0'
       classpath-command: 'clojure -Spath -A:cli'
+      nvd-config-filename: '.nvd/config.json'
 
   docker:
     needs:

--- a/.github/workflows/nvd_sched.yml
+++ b/.github/workflows/nvd_sched.yml
@@ -2,7 +2,7 @@ name: Periodic Vulnerability Scan
 
 on:
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 8 * * 1-5' # Every weekday at 8:00 AM
 
 jobs:
   nvd_scan:
@@ -11,3 +11,18 @@ jobs:
       nvd-clojure-version: '2.0.0'
       classpath-command: 'clojure -Spath -A:cli'
       nvd-config-filename: '.nvd/config.json'
+
+  notify_slack:
+    runs-on: ubuntu-latest
+    needs: nvd_scan
+    if: ${{ always() && (needs.nvd_scan.result == 'failure') }}
+    steps:
+    - name: Notify Slack LRSPipe NVD Scan Reporter 
+      uses: slackapi/slack-github-action@v1.18.0
+      with:
+        payload: |
+          {
+            "run_link": "https://github.com/yetanalytics/xapipe/actions/runs/${{ github.run_id }}"
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nvd_sched.yml
+++ b/.github/workflows/nvd_sched.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   nvd_scan:
-    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.2
+    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.3
     with:
       nvd-clojure-version: '2.0.0'
       classpath-command: 'clojure -Spath -A:cli'
+      nvd-config-filename: '.nvd/config.json'

--- a/.nvd/config.json
+++ b/.nvd/config.json
@@ -1,0 +1,3 @@
+{
+    "nvd": {"suppression-file": ".nvd/suppression.xml"}
+}

--- a/.nvd/suppression.xml
+++ b/.nvd/suppression.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+   <suppress>
+      <notes><![CDATA[
+      file name: core.async-1.5.648.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.clojure/core\.async@.*$</packageUrl>
+      <cpe>cpe:/a:async_project:async</cpe>
+   </suppress>
+</suppressions>

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,6 @@
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}
         org.clojure/core.async {:mvn/version "1.3.618"}
         clj-http/clj-http {:mvn/version "3.12.3"}
-        cheshire/cheshire {:mvn/version "5.10.1"}
         com.taoensso/carmine {:mvn/version "3.1.0"}
         commons-fileupload/commons-fileupload {:mvn/version "1.4"}
         com.yetanalytics/xapi-schema
@@ -17,7 +16,22 @@
          :git/tag "v0.8.0"
          :exclusions [org.clojure/clojurescript]}
         org.clojure/data.json {:mvn/version "2.4.0"}
-        com.cognitect/transit-clj {:mvn/version "1.0.324"}}
+        com.cognitect/transit-clj {:mvn/version "1.0.324"}
+        ;; Include Jackson to avoid CVE
+        cheshire/cheshire
+        {:mvn/version "5.10.2"
+         :exclusions [com.fasterxml.jackson.core/jackson-core
+                      com.fasterxml.jackson.dataformat/jackson-dataformat-smile
+                      com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
+                      com.fasterxml.jackson.core/jackson-databind]}
+        com.fasterxml.jackson.core/jackson-core
+        {:mvn/version "2.13.2"}
+        com.fasterxml.jackson.dataformat/jackson-dataformat-smile
+        {:mvn/version "2.13.2"}
+        com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
+        {:mvn/version "2.13.2"}
+        com.fasterxml.jackson.core/jackson-databind
+        {:mvn/version "2.13.2.1"}}
  :aliases
  {:cli {:extra-paths ["src/cli"]
         :extra-deps {org.clojure/tools.cli {:mvn/version "1.0.206"}


### PR DESCRIPTION
- Remove CVE-2020-36518 by updating Cheshire and Jackson dependencies
- Suppress CVE-2021-43138 by adding NVD config
- Add Slack notifications to periodic NVD scanning (~**TODO:** Need to add the `SLACK_WORFKLOW_URL` secret~ Done!)