### PR TITLE
LRS-72 testing updates for deduplicated attachments, pan fixes

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,15 +5,13 @@
         com.taoensso/carmine {:mvn/version "3.1.0"}
         commons-fileupload/commons-fileupload {:mvn/version "1.4"}
         com.yetanalytics/xapi-schema
-        {:git/url "https://github.com/yetanalytics/xapi-schema.git"
-         :sha "5cb168a1af2e0d4e465db067ba2e44bcde71bdc9"
+        {:mvn/version "1.2.0"
          :exclusions [org.clojure/clojure
                       org.clojure/clojurescript
                       org.clojure/data.json]}
         org.clojure/tools.logging {:mvn/version "1.1.0"}
-        io.github.yetanalytics/project-persephone
-        {:git/sha "75e62d5"
-         :git/tag "v0.8.0"
+        com.yetanalytics/project-persephone
+        {:mvn/version "0.8.1"
          :exclusions [org.clojure/clojurescript]}
         org.clojure/data.json {:mvn/version "2.4.0"}
         com.cognitect/transit-clj {:mvn/version "1.0.324"}
@@ -52,8 +50,7 @@
           io.github.cognitect-labs/test-runner
           {:git/url "https://github.com/cognitect-labs/test-runner"
            :sha "dd6da11611eeb87f08780a30ac8ea6012d4c05ce"}
-          com.yetanalytics/lrs {:git/url "https://github.com/yetanalytics/lrs.git"
-                                :sha "f58af8f7a096f91ecffeb320ed0e2a4386e026da"}
+          com.yetanalytics/lrs {:mvn/version "1.2.11"}
           io.pedestal/pedestal.jetty {:mvn/version "0.5.9"}
           ;; Some integration tests use logback
           ch.qos.logback/logback-classic {:mvn/version "1.2.9"
@@ -63,8 +60,7 @@
           org.slf4j/jcl-over-slf4j {:mvn/version "1.7.26"}
           org.slf4j/log4j-over-slf4j {:mvn/version "1.7.26"}
           com.yetanalytics/datasim
-          {:git/url    "https://github.com/yetanalytics/datasim.git"
-           :sha        "d55f24098aca78db69e2f03d4f202ce58b5fdb49"
+          {:mvn/version "0.1.3"
            :exclusions [org.clojure/test.check
                         com.yetanalytics/project-pan
                         com.yetanalytics/xapi-schema]}}

--- a/src/lib/com/yetanalytics/xapipe/filter.clj
+++ b/src/lib/com/yetanalytics/xapipe/filter.clj
@@ -147,7 +147,7 @@
           (fn []
             (s/gen per/state-info-map-spec
                    ;; TODO: gen error for pan strings
-                   {:com.yetanalytics.pan.axioms/string
+                   {:com.yetanalytics.pan.axioms/uri
                     (fn [] (s/gen ::xs/iri))})))))
 
 (s/fdef evict-keys

--- a/src/lib/com/yetanalytics/xapipe/filter/concept.clj
+++ b/src/lib/com/yetanalytics/xapipe/filter/concept.clj
@@ -2,10 +2,10 @@
   "Functions to apply concept-based filtering to statement streams."
   (:require [com.yetanalytics.persephone.template :as pt]
             [com.yetanalytics.persephone :as p]
-            [com.yetanalytics.pan.objects.concepts.verbs :as v]
-            [com.yetanalytics.pan.objects.concepts.activity-types :as at]
+            [com.yetanalytics.pan.objects.concepts.verb :as v]
+            [com.yetanalytics.pan.objects.concepts.activity-type :as at]
             [com.yetanalytics.pan.objects.template :as t]
-            [com.yetanalytics.pan.objects.concepts.attachment-usage-types :as aut]
+            [com.yetanalytics.pan.objects.concepts.attachment-usage-type :as aut]
             [xapi-schema.spec :as xs]
             [clojure.spec.alpha :as s]))
 


### PR DESCRIPTION
[LRS-72] Update testing to use `lrs` version `1.2.11` with in-memory LRSs that handle and return deduped attachments.

Other dep updates as needed, including fixes for namespaces + changed specs in Pan.

[LRS-72]: https://yet.atlassian.net/browse/LRS-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ