### PR TITLE
suppress CVE-2022-23172, CVE-2022-23173 on priority map libs

### DIFF
--- a/.nvd/suppression.xml
+++ b/.nvd/suppression.xml
@@ -7,33 +7,19 @@
         <packageUrl regex="true">^pkg:maven/org\.clojure/core\.async@.*$</packageUrl>
         <cpe>cpe:/a:async_project:async</cpe>
     </suppress>
-    <!-- The next 4 are false positives on clj/cljs priority map -->
+    <!-- The next 2 are false positives on clj/cljs priority map -->
     <suppress>
         <notes><![CDATA[
         file name: cljs-priority-map-1.2.1.jar
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/tailrecursion/cljs\-priority\-map@.*$</packageUrl>
-        <cve>CVE-2022-23172</cve>
+        <cpe>cpe:/a:priority-software:priority</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-        file name: cljs-priority-map-1.2.1.jar
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/tailrecursion/cljs\-priority\-map@.*$</packageUrl>
-        <cve>CVE-2022-23173</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-        file name: data.priority-map-1.0.0.jar
+        file name: data.priority-map-1.1.0.jar
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.clojure/data\.priority\-map@.*$</packageUrl>
-        <cve>CVE-2022-23172</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-        file name: data.priority-map-1.0.0.jar
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.clojure/data\.priority\-map@.*$</packageUrl>
-        <cve>CVE-2022-23173</cve>
+        <cpe>cpe:/a:priority-software:priority</cpe>
     </suppress>
 </suppressions>

--- a/.nvd/suppression.xml
+++ b/.nvd/suppression.xml
@@ -1,10 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-   <suppress>
-      <notes><![CDATA[
-      file name: core.async-1.5.648.jar
-      ]]></notes>
-      <packageUrl regex="true">^pkg:maven/org\.clojure/core\.async@.*$</packageUrl>
-      <cpe>cpe:/a:async_project:async</cpe>
-   </suppress>
+    <suppress>
+        <notes><![CDATA[
+        file name: core.async-1.5.648.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.clojure/core\.async@.*$</packageUrl>
+        <cpe>cpe:/a:async_project:async</cpe>
+    </suppress>
+    <!-- The next 4 are false positives on clj/cljs priority map -->
+    <suppress>
+        <notes><![CDATA[
+        file name: cljs-priority-map-1.2.1.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/tailrecursion/cljs\-priority\-map@.*$</packageUrl>
+        <cve>CVE-2022-23172</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        file name: cljs-priority-map-1.2.1.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/tailrecursion/cljs\-priority\-map@.*$</packageUrl>
+        <cve>CVE-2022-23173</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        file name: data.priority-map-1.0.0.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.clojure/data\.priority\-map@.*$</packageUrl>
+        <cve>CVE-2022-23172</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        file name: data.priority-map-1.0.0.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.clojure/data\.priority\-map@.*$</packageUrl>
+        <cve>CVE-2022-23173</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Another day, two more clojure libs falsely identified as vulnerable.