### PR TITLE
[PIP-82] Update CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
       - '*'
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - 'main'
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get an env
-        uses: yetanalytics/actions/setup-env@v0.0.2
+        uses: yetanalytics/actions/setup-env@v0.0.4
 
       - name: Cache Deps
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.m2
@@ -49,13 +49,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get an env
-        uses: yetanalytics/actions/setup-env@v0.0.2
+        uses: yetanalytics/actions/setup-env@v0.0.4
 
       - name: Cache Deps
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.m2
@@ -69,7 +69,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: yetanalytics/xapipe
           tags: |
@@ -80,13 +80,13 @@ jobs:
 
       - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_CI_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - '*'
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - 'main'
 
 jobs:
   test:

--- a/.github/workflows/nvd_sched.yml
+++ b/.github/workflows/nvd_sched.yml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ always() && (needs.nvd_scan.result == 'failure') }}
     steps:
     - name: Notify Slack LRSPipe NVD Scan Reporter 
-      uses: slackapi/slack-github-action@v1.18.0
+      uses: slackapi/slack-github-action@v1.23.0
       with:
         payload: |
           {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
           zip -r ../../xapipe.zip ./
 
       - name: Craft Draft Release
-        uses: softprops/action-gh-release@v1 # TODO: Update
+        uses: softprops/action-gh-release@v1
         with:
           draft: true
           files: 'xapipe.zip'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           files: 'xapipe.zip'
 
       - name: Deploy Documentation (Tag Pushes)
-        uses: JamesIves/github-pages-deploy-action@v4.4.1 # TODO: Check for set-output
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: gh-pages
           folder: target/bundle/doc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       modules: ${{ steps.echo-modules.outputs.modules }}
   build_jre:
     needs: get_modules
-    uses: yetanalytics/runtimer/.github/workflows/runtimer.yml@cf8c77d465f08962cd7901005b8cf197a6149ac1
+    uses: yetanalytics/runtimer/.github/workflows/runtimer.yml@0.1.2-java-11-temurin
     with:
       java-version: '11'
       java-distribution: 'temurin'
@@ -52,22 +52,22 @@ jobs:
       - name: Download macOS-latest Artifact
         uses: actions/download-artifact@v3
         with:
-          name: macos-10.15-jre
+          name: macos-11-jre
 
       - name: Download windows-latest Artifact
         uses: actions/download-artifact@v3
         with:
-          name: windows-2019-jre
+          name: windows-2022-jre
 
       - name: Unzip the runtimes
         run: |
           mkdir -p target/bundle/runtimes
           unzip ubuntu-20.04-jre.zip -d target/bundle/runtimes
           mv target/bundle/runtimes/ubuntu-20.04 target/bundle/runtimes/linux
-          unzip macos-10.15-jre.zip -d target/bundle/runtimes
-          mv target/bundle/runtimes/macos-10.15 target/bundle/runtimes/macos
-          unzip windows-2019-jre.zip -d target/bundle/runtimes
-          mv target/bundle/runtimes/windows-2019 target/bundle/runtimes/windows
+          unzip macos-11-jre.zip -d target/bundle/runtimes
+          mv target/bundle/runtimes/macos-11 target/bundle/runtimes/macos
+          unzip windows-2022-jre.zip -d target/bundle/runtimes
+          mv target/bundle/runtimes/windows-2022 target/bundle/runtimes/windows
 
       - name: Zip the bundle
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   get_modules:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: echo-modules
         run: echo "::set-output name=modules::$(cat .java_modules)"
     outputs:
@@ -27,13 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get an env
-        uses: yetanalytics/actions/setup-env@v0.0.2
+        uses: yetanalytics/actions/setup-env@v0.0.4
 
       - name: Cache Deps
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.m2
@@ -45,17 +45,17 @@ jobs:
         run: make bundle BUNDLE_RUNTIMES=false
 
       - name: Download ubuntu-latest Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ubuntu-20.04-jre
 
       - name: Download macOS-latest Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: macos-10.15-jre
 
       - name: Download windows-latest Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: windows-2019-jre
 
@@ -75,13 +75,13 @@ jobs:
           zip -r ../../xapipe.zip ./
 
       - name: Craft Draft Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v1 # TODO: Update
         with:
           draft: true
           files: 'xapipe.zip'
 
       - name: Deploy Documentation (Tag Pushes)
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        uses: JamesIves/github-pages-deploy-action@4.4.1 # TODO: Check for set-output
         with:
           branch: gh-pages
           folder: target/bundle/doc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,16 @@ jobs:
   get_modules:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - id: echo-modules
-        run: echo "::set-output name=modules::$(cat .java_modules)"
+      - name: Checkout project
+        uses: actions/checkout@v3
+
+      - name: List Java modules
+        id: echo-modules
+        run: echo "modules=$(cat .java_modules)" >> $GITHUB_OUTPUT
+
     outputs:
       modules: ${{ steps.echo-modules.outputs.modules }}
+  
   build_jre:
     needs: get_modules
     uses: yetanalytics/runtimer/.github/workflows/runtimer.yml@0.1.2-java-11-temurin
@@ -22,6 +27,7 @@ jobs:
       java-version: '11'
       java-distribution: 'temurin'
       java-modules: ${{ needs.get_modules.outputs.modules }}
+  
   build:
     needs: build_jre
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           files: 'xapipe.zip'
 
       - name: Deploy Documentation (Tag Pushes)
-        uses: JamesIves/github-pages-deploy-action@4.4.1 # TODO: Check for set-output
+        uses: JamesIves/github-pages-deploy-action@v4.4.1 # TODO: Check for set-output
         with:
           branch: gh-pages
           folder: target/bundle/doc


### PR DESCRIPTION
- Replaced deprecated `set-output` command
- Updated the following actions and composite workflows:
  - runtimer workflow to 0.1.2-java-11-temurin
  - nvd-scan workflow to v0.0.4
  - yetanalytics/actions/setup-env to v0.0.4
  - actions/cache from v2 to v3
  - actions/download-artifact from v2 to v3
  - actions/upload-artifact from v2 to v3
  - JamesIves/github-pages-deploy-action` to v4.4.1
  - docker/login-action to v2
  - docker/metadata-action to v4
  - docker/build-push-action to v3
  - slackapi/slack-github-action to v1.23.0
- Update OS versions:
  - Windows from 2019 to 2022
  - MacOS from 10.15 to 11