### PR TITLE
exclude msgpack to clear CVE-2022-41719

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -15,6 +15,7 @@
          :exclusions [org.clojure/clojurescript]}
         org.clojure/data.json {:mvn/version "2.4.0"}
         com.cognitect/transit-clj {:mvn/version "1.0.324"
+                                   ;; clears CVE-2022-41719
                                    :exclusions [org.msgpack/msgpack]}
         cheshire/cheshire {:mvn/version "5.11.0"}}
  :aliases

--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,8 @@
         {:mvn/version "0.8.1"
          :exclusions [org.clojure/clojurescript]}
         org.clojure/data.json {:mvn/version "2.4.0"}
-        com.cognitect/transit-clj {:mvn/version "1.0.324"}
+        com.cognitect/transit-clj {:mvn/version "1.0.324"
+                                   :exclusions [org.msgpack/msgpack]}
         cheshire/cheshire {:mvn/version "5.11.0"}}
  :aliases
  {:cli {:extra-paths ["src/cli"]


### PR DESCRIPTION
Likely an FP, but we don't use the msgpack functionality in `transit-clj`. https://nvd.nist.gov/vuln/detail/CVE-2022-41719