### PR TITLE
CVE-2023-24998 update commons-fileupload to 1.5

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         org.clojure/core.async {:mvn/version "1.3.618"}
         clj-http/clj-http {:mvn/version "3.12.3"}
         com.taoensso/carmine {:mvn/version "3.1.0"}
-        commons-fileupload/commons-fileupload {:mvn/version "1.4"}
+        commons-fileupload/commons-fileupload {:mvn/version "1.5"}
         com.yetanalytics/xapi-schema
         {:mvn/version "1.2.0"
          :exclusions [org.clojure/clojure


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2023-24998

https://lists.apache.org/thread/4xl4l09mhwg4vgsk7dxqogcjrobrrdoy