### PR TITLE
update CloudFormation template to use v0.0.25

### DIFF
--- a/dev-resources/templates/lrspipe_ec2.yml
+++ b/dev-resources/templates/lrspipe_ec2.yml
@@ -36,7 +36,7 @@ Parameters:
   LrsPipeVersion:
     Description: Version of LRSPipe to download and install (public release versions on GitHub)
     Type: String
-    Default: v0.0.15
+    Default: v0.0.25
 
   LogRetentionInDays:
     Description: How long to retain Cloudwatch Logs


### PR DESCRIPTION
Version default in template was quite old, bring it up to current.