### PR TITLE
PIP-88 Dependency Graph Support

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -1,0 +1,32 @@
+name: Deps
+
+on:
+  push:
+    branches:
+      - '*'
+jobs:
+  deps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+
+      - name: Setup CI Environment
+        uses: yetanalytics/action-setup-env@v1
+
+      - name: Cache Deps
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2
+            ~/.gitlibs
+          key: ${{ runner.os }}-deps-${{ hashFiles('deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-deps-
+
+      - name: Make a POM
+        run: make clean pom.xml
+
+      - name: Submit Dependency Snapshot
+        uses: advanced-security/maven-dependency-submission-action@v3

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .phony: test bench clean bundle bundle-help ci
 
 clean:
-	rm -rf target dev-resources/bench/*.json
+	rm -rf target dev-resources/bench/*.json pom.xml
 
 JAVA_MODULES ?= $(shell cat .java_modules)
 
@@ -61,3 +61,7 @@ bundle: target/bundle
 # Run the bundle's help, used for compile-time sanity checks
 bundle-help: target/bundle
 	cd target/bundle; bin/run.sh --help
+
+# Generate a POM for dependency graph resolution
+pom.xml:
+	clojure -Acli -Spom


### PR DESCRIPTION
[PIP-88] Devise a method for providing dependency graph information to github.

This PR:
* Adds a Makefile target that creates a `pom.xml` with the aliases used in the release build
* Uses that pom to submit dependency graph information to GitHub

[PIP-88]: https://yet.atlassian.net/browse/PIP-88?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ