### PR TITLE
Update Dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
   nvd_scan:
     uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.4
     with:
-      nvd-clojure-version: '2.9.0'
+      nvd-clojure-version: '3.6.0'
       classpath-command: 'clojure -Spath -A:cli'
       nvd-config-filename: '.nvd/config.json'
 

--- a/.github/workflows/nvd_sched.yml
+++ b/.github/workflows/nvd_sched.yml
@@ -8,7 +8,7 @@ jobs:
   nvd_scan:
     uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.4
     with:
-      nvd-clojure-version: '2.9.0'
+      nvd-clojure-version: '3.6.0'
       classpath-command: 'clojure -Spath -A:cli'
       nvd-config-filename: '.nvd/config.json'
 

--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,9 @@
         {:mvn/version "0.8.1"
          :exclusions [org.clojure/clojurescript]}
         org.clojure/data.json {:mvn/version "2.4.0"}
-        com.cognitect/transit-clj {:mvn/version "1.0.333"}
+        com.cognitect/transit-clj {:mvn/version "1.0.333"
+                                   ;; clears CVE-2022-41719
+                                   :exclusions [org.msgpack/msgpack]}
         cheshire/cheshire {:mvn/version "5.12.0"}}
  :aliases
  {:cli {:extra-paths ["src/cli"]

--- a/deps.edn
+++ b/deps.edn
@@ -15,9 +15,8 @@
          :exclusions [org.clojure/clojurescript]}
         org.clojure/data.json {:mvn/version "2.4.0"}
         com.cognitect/transit-clj {:mvn/version "1.0.333"
-                                   ;; clears CVE-2023-5072 and CVE-2022-41719
-                                   :exclusions [com.fasterxml.jackson.core/jackson-core
-                                                org.msgpack/msgpack]}
+                                   ;; clears CVE-2022-41719
+                                   :exclusions [org.msgpack/msgpack]}
         cheshire/cheshire {:mvn/version "5.12.0"}}
  :aliases
  {:cli {:extra-paths ["src/cli"]

--- a/deps.edn
+++ b/deps.edn
@@ -14,9 +14,7 @@
         {:mvn/version "0.8.1"
          :exclusions [org.clojure/clojurescript]}
         org.clojure/data.json {:mvn/version "2.4.0"}
-        com.cognitect/transit-clj {:mvn/version "1.0.333"
-                                   ;; clears CVE-2022-41719
-                                   :exclusions [org.msgpack/msgpack]}
+        com.cognitect/transit-clj {:mvn/version "1.0.333"}
         cheshire/cheshire {:mvn/version "5.12.0"}}
  :aliases
  {:cli {:extra-paths ["src/cli"]

--- a/deps.edn
+++ b/deps.edn
@@ -18,7 +18,9 @@
                                    ;; clears CVE-2023-5072 and CVE-2022-41719
                                    :exclusions [com.fasterxml.jackson.core/jackson-core
                                                 org.msgpack/msgpack]}
-        cheshire/cheshire {:mvn/version "5.12.0"}}
+        cheshire/cheshire {:mvn/version "5.12.0"
+                           :exclusions [com.fasterxml.jackson.core/jackson-core]}
+        com.fasterxml.jackson.core/jackson-core {:mvn/version "2.16.1"}}
  :aliases
  {:cli {:extra-paths ["src/cli"]
         :extra-deps {org.clojure/tools.cli {:mvn/version "1.0.206"}

--- a/deps.edn
+++ b/deps.edn
@@ -15,8 +15,9 @@
          :exclusions [org.clojure/clojurescript]}
         org.clojure/data.json {:mvn/version "2.4.0"}
         com.cognitect/transit-clj {:mvn/version "1.0.333"
-                                   ;; clears CVE-2022-41719
-                                   :exclusions [org.msgpack/msgpack]}
+                                   ;; clears CVE-2023-5072 and CVE-2022-41719
+                                   :exclusions [com.fasterxml.jackson.core/jackson-core
+                                                org.msgpack/msgpack]}
         cheshire/cheshire {:mvn/version "5.12.0"}}
  :aliases
  {:cli {:extra-paths ["src/cli"]

--- a/deps.edn
+++ b/deps.edn
@@ -17,7 +17,7 @@
         com.cognitect/transit-clj {:mvn/version "1.0.324"
                                    ;; clears CVE-2022-41719
                                    :exclusions [org.msgpack/msgpack]}
-        cheshire/cheshire {:mvn/version "5.11.0"}}
+        cheshire/cheshire {:mvn/version "5.12.0"}}
  :aliases
  {:cli {:extra-paths ["src/cli"]
         :extra-deps {org.clojure/tools.cli {:mvn/version "1.0.206"}

--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,7 @@
         {:mvn/version "0.8.1"
          :exclusions [org.clojure/clojurescript]}
         org.clojure/data.json {:mvn/version "2.4.0"}
-        com.cognitect/transit-clj {:mvn/version "1.0.324"
+        com.cognitect/transit-clj {:mvn/version "1.0.333"
                                    ;; clears CVE-2022-41719
                                    :exclusions [org.msgpack/msgpack]}
         cheshire/cheshire {:mvn/version "5.12.0"}}

--- a/deps.edn
+++ b/deps.edn
@@ -18,9 +18,7 @@
                                    ;; clears CVE-2023-5072 and CVE-2022-41719
                                    :exclusions [com.fasterxml.jackson.core/jackson-core
                                                 org.msgpack/msgpack]}
-        cheshire/cheshire {:mvn/version "5.12.0"
-                           :exclusions [com.fasterxml.jackson.core/jackson-core]}
-        com.fasterxml.jackson.core/jackson-core {:mvn/version "2.16.1"}}
+        cheshire/cheshire {:mvn/version "5.12.0"}}
  :aliases
  {:cli {:extra-paths ["src/cli"]
         :extra-deps {org.clojure/tools.cli {:mvn/version "1.0.206"}

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
  {:cli {:extra-paths ["src/cli"]
         :extra-deps {org.clojure/tools.cli {:mvn/version "1.0.206"}
                      ch.qos.logback/logback-classic
-                     {:mvn/version "1.2.9"
+                     {:mvn/version "1.3.14"
                       :exclusions [org.slf4j/slf4j-api]}
                      org.slf4j/slf4j-api {:mvn/version "1.7.26"}
                      org.slf4j/jul-to-slf4j {:mvn/version "1.7.26"}
@@ -39,7 +39,7 @@
           com.yetanalytics/lrs {:mvn/version "1.2.11"}
           io.pedestal/pedestal.jetty {:mvn/version "0.5.9"}
           ;; Some integration tests use logback
-          ch.qos.logback/logback-classic {:mvn/version "1.2.9"
+          ch.qos.logback/logback-classic {:mvn/version "1.3.14"
                                           :exclusions [org.slf4j/slf4j-api]}
           org.slf4j/slf4j-api {:mvn/version "1.7.26"}
           org.slf4j/jul-to-slf4j {:mvn/version "1.7.26"}


### PR DESCRIPTION
Update Cheshire, transit-clj, and logback to their latest versions. In addition, update the nvd-clojure version used in order to fix false positive CVEs.