### PR TITLE
Update slf4j API to fix failing runtime

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -24,10 +24,10 @@
                      ch.qos.logback/logback-classic
                      {:mvn/version "1.3.14"
                       :exclusions [org.slf4j/slf4j-api]}
-                     org.slf4j/slf4j-api {:mvn/version "1.7.26"}
-                     org.slf4j/jul-to-slf4j {:mvn/version "1.7.26"}
-                     org.slf4j/jcl-over-slf4j {:mvn/version "1.7.26"}
-                     org.slf4j/log4j-over-slf4j {:mvn/version "1.7.26"}
+                     org.slf4j/slf4j-api {:mvn/version "2.0.12"}
+                     org.slf4j/jul-to-slf4j {:mvn/version "2.0.12"}
+                     org.slf4j/jcl-over-slf4j {:mvn/version "2.0.12"}
+                     org.slf4j/log4j-over-slf4j {:mvn/version "2.0.12"}
 
                      clj-commons/iapetos {:mvn/version "0.1.12"}
                      io.prometheus/simpleclient_hotspot {:mvn/version "0.12.0"}}}
@@ -43,10 +43,10 @@
           ;; Some integration tests use logback
           ch.qos.logback/logback-classic {:mvn/version "1.3.14"
                                           :exclusions [org.slf4j/slf4j-api]}
-          org.slf4j/slf4j-api {:mvn/version "1.7.26"}
-          org.slf4j/jul-to-slf4j {:mvn/version "1.7.26"}
-          org.slf4j/jcl-over-slf4j {:mvn/version "1.7.26"}
-          org.slf4j/log4j-over-slf4j {:mvn/version "1.7.26"}
+          org.slf4j/slf4j-api {:mvn/version "2.0.12"}
+          org.slf4j/jul-to-slf4j {:mvn/version "2.0.12"}
+          org.slf4j/jcl-over-slf4j {:mvn/version "2.0.12"}
+          org.slf4j/log4j-over-slf4j {:mvn/version "2.0.12"}
           com.yetanalytics/datasim
           {:mvn/version "0.1.3"
            :exclusions [org.clojure/test.check


### PR DESCRIPTION
We updated logback without the corresponding update to slf4j. This fixes that.