### PR TITLE
update clojure to clear CVE-2024-22871

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src/lib" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.10.3"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.2"}
         org.clojure/core.async {:mvn/version "1.3.618"}
         clj-http/clj-http {:mvn/version "3.12.3"}
         com.taoensso/carmine {:mvn/version "3.1.0"}


### PR DESCRIPTION
The clojure core team has added mitigation for CVE-2024-22871 in version 1.11.2