### PR TITLE
Update runtimer and other actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
       - '*'
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - 'main'
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get an env
-        uses: yetanalytics/actions/setup-env@v2
+        uses: yetanalytics/action-setup-env@v2
 
       - name: Cache Deps
         uses: actions/cache@v3
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get an env
-        uses: yetanalytics/actions/setup-env@v2
+        uses: yetanalytics/action-setup-env@v2
 
       - name: Cache Deps
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get an env
-        uses: yetanalytics/actions/setup-env@v0.0.4
+        uses: yetanalytics/actions/setup-env@v2
 
       - name: Cache Deps
         uses: actions/cache@v3
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get an env
-        uses: yetanalytics/actions/setup-env@v0.0.4
+        uses: yetanalytics/actions/setup-env@v2
 
       - name: Cache Deps
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: yetanalytics/action-setup-env@v2
 
       - name: Cache Deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2
@@ -55,7 +55,7 @@ jobs:
         uses: yetanalytics/action-setup-env@v2
 
       - name: Cache Deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get an env
         uses: yetanalytics/action-setup-env@v2
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get an env
         uses: yetanalytics/action-setup-env@v2

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -16,7 +16,7 @@ jobs:
         uses: yetanalytics/action-setup-env@v2
 
       - name: Cache Deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup CI Environment
         uses: yetanalytics/action-setup-env@v2

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - '*'
+
 jobs:
   deps:
     runs-on: ubuntu-latest

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup CI Environment
-        uses: yetanalytics/action-setup-env@v1
+        uses: yetanalytics/action-setup-env@v2
 
       - name: Cache Deps
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get an env
-        uses: yetanalytics/actions/setup-env@v2
+        uses: yetanalytics/action-setup-env@v2
 
       - name: Cache Deps
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: List Java modules
         id: echo-modules
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get an env
         uses: yetanalytics/action-setup-env@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: yetanalytics/action-setup-env@v2
 
       - name: Cache Deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,21 +47,22 @@ jobs:
           key: ${{ runner.os }}-deps-${{ hashFiles('deps.edn') }}
           restore-keys: |
             ${{ runner.os }}-deps-
+      
       - name: Build Xapipe
         run: make bundle BUNDLE_RUNTIMES=false
 
       - name: Download ubuntu-latest Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ubuntu-22.04-jre
 
       - name: Download macOS-latest Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: macos-14-jre
 
       - name: Download windows-latest Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: windows-2022-jre
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,12 @@ jobs:
       - name: Download ubuntu-latest Artifact
         uses: actions/download-artifact@v3
         with:
-          name: ubuntu-20.04-jre
+          name: ubuntu-22.04-jre
 
       - name: Download macOS-latest Artifact
         uses: actions/download-artifact@v3
         with:
-          name: macos-12-jre
+          name: macos-14-jre
 
       - name: Download windows-latest Artifact
         uses: actions/download-artifact@v3
@@ -68,10 +68,10 @@ jobs:
       - name: Unzip the runtimes
         run: |
           mkdir -p target/bundle/runtimes
-          unzip ubuntu-20.04-jre.zip -d target/bundle/runtimes
-          mv target/bundle/runtimes/ubuntu-20.04 target/bundle/runtimes/linux
-          unzip macos-12-jre.zip -d target/bundle/runtimes
-          mv target/bundle/runtimes/macos-12 target/bundle/runtimes/macos
+          unzip ubuntu-22.04-jre.zip -d target/bundle/runtimes
+          mv target/bundle/runtimes/ubuntu-22.04 target/bundle/runtimes/linux
+          unzip macos-14-jre.zip -d target/bundle/runtimes
+          mv target/bundle/runtimes/macos-14 target/bundle/runtimes/macos
           unzip windows-2022-jre.zip -d target/bundle/runtimes
           mv target/bundle/runtimes/windows-2022 target/bundle/runtimes/windows
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
   
   build_jre:
     needs: get_modules
-    uses: yetanalytics/runtimer/.github/workflows/runtimer.yml@0.1.3-java-11-temurin
+    uses: yetanalytics/workflow-runtimer/.github/workflows/runtimer.yml@v2
     with:
       java-version: '11'
       java-distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get an env
-        uses: yetanalytics/actions/setup-env@v0.0.4
+        uses: yetanalytics/actions/setup-env@v2
 
       - name: Cache Deps
         uses: actions/cache@v3

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ failures/
 /logs/
 .DS_Store
 /dev-resources/bench/*.json
+.clj-kondo/
+.lsp/


### PR DESCRIPTION
Update the runtimer workflow to the latest repo and version, in order to use non-deprecated versions of MacOS and other operating systems. In addition, update important (not every) action, including all `actions/` actions and `yetanalytics/actions/setup-env`.

Also kill CI on pull requests since it's redundant, since we already do CI on each push.