### PR TITLE
Depedendency Audit Tasks:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.phony: test bench clean bundle bundle-help ci sbom sbom-csv
+.phony: test bench clean bundle bundle-help ci sbom sbom-csv runtime-info
 
 clean:
 	rm -rf target dev-resources/bench/*.json pom.xml
@@ -75,3 +75,10 @@ sbom: pom.xml
 
 sbom-csv: sbom
 	jq -r -f ./dev-resources/sbom/sbom_flat.jq ./target/xapipe.json > ./target/xapipe-sbom.csv
+
+target/runtime-info.txt: bundle Dockerfile
+	mkdir -p target
+	docker build -t xapipe:local .
+	docker run --rm --entrypoint sh xapipe:local -c 'set -e; echo "== OS =="; cat /etc/os-release; echo; echo "== Kernel =="; uname -a; echo; echo "== Java =="; /xapipe/runtimes/linux/bin/java -version 2>&1; echo; echo "== Packages =="; apk info -vv' > target/runtime-info.txt
+
+runtime-info: target/runtime-info.txt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.phony: test bench clean bundle bundle-help ci
+.phony: test bench clean bundle bundle-help ci sbom sbom-csv
 
 clean:
 	rm -rf target dev-resources/bench/*.json pom.xml
@@ -65,3 +65,13 @@ bundle-help: target/bundle
 # Generate a POM for dependency graph resolution
 pom.xml:
 	clojure -Acli -Spom
+
+sbom: pom.xml
+	mvn -q org.cyclonedx:cyclonedx-maven-plugin:makeAggregateBom \
+	  -DoutputFormat=json \
+	  -DoutputName=xapipe \
+	  -DschemaVersion=1.6 \
+	  -DprojectType=application
+
+sbom-csv: sbom
+	jq -r -f ./dev-resources/sbom/sbom_flat.jq ./target/xapipe.json > ./target/xapipe-sbom.csv

--- a/dev-resources/sbom/sbom_flat.jq
+++ b/dev-resources/sbom/sbom_flat.jq
@@ -1,0 +1,17 @@
+def pkg_name(c):
+  if (c.group? // "") != "" then "\(c.group)/\(c.name)" else (c.name // "") end;
+
+[
+  .metadata.component?,
+  .components[]?
+]
+| map(select(. != null))
+| map({
+    package: pkg_name(.),
+    source: (.purl // .["bom-ref"] // .author // .publisher // "unknown"),
+    version: (.version // "unknown")
+  })
+| unique
+| sort_by(.package, .version)
+| (["package","source","version"] | @csv),
+  (.[] | [ .package, .source, .version ] | @csv)


### PR DESCRIPTION
These are helper tasks that do the following:
**sbom-csv:** generate a condensed CSV version of an SBOM
**runtime-info:** uses docker to dump information about the runtime environment, includes the following:
- OS version
- Kernel version
- Java version
- Packages